### PR TITLE
Bump `rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libsecp256k1"
 description = "Pure Rust secp256k1 implementation."
 license = "Apache-2.0"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/paritytech/libsecp256k1"
 keywords = [ "crypto", "ECDSA", "secp256k1", "bitcoin", "no_std" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 name = "secp256k1"
 
 [dependencies]
-rand = { version = "0.6", default-features = false }
+rand = { version = "0.7", default-features = false }
 hmac-drbg = "0.2"
 sha2 = { version = "0.8", default-features = false }
 digest = "0.8"


### PR DESCRIPTION
Version `0.6` of `rand` does not work on `wasm32-wasi`, so we need to update it if we want to support that target.