### PR TITLE
Bump to 0.3.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libsecp256k1"
 description = "Pure Rust secp256k1 implementation."
 license = "Apache-2.0"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/paritytech/libsecp256k1"
 keywords = [ "crypto", "ECDSA", "secp256k1", "bitcoin", "no_std" ]


### PR DESCRIPTION
This should be also published on crates.io, since now wasm builds are broken in some repos (see https://gitlab.parity.io/parity/substrate/-/jobs/340291)