### PR TITLE
Fix the PartialEq impl of Field.

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -451,6 +451,8 @@ impl Field {
         debug_assert!(self.verify());
     }
 
+    /// Compute the additive inverse of this element. Takes the maximum
+    /// expected magnitude of this element as an argument.
     pub fn neg(&self, m: u32) -> Field {
         let mut ret = Field::default();
         ret.neg_in_place(self, m);
@@ -1461,7 +1463,7 @@ impl MulAssign<Field> for Field {
 
 impl PartialEq for Field {
     fn eq(&self, other: &Field) -> bool {
-        let mut na = self.neg(1);
+        let mut na = self.neg(self.magnitude);
         na += other;
         return na.normalizes_to_zero();
     }

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -384,3 +384,29 @@ fn test_pubkey_combine() {
 
     assert_eq!(PublicKey::combine(&[pk1, pk2]).unwrap(), cpk);
 }
+
+#[test]
+fn test_pubkey_equality() {
+    for _ in 0 .. 10 {
+        let secret = SecretKey::random(&mut rand::thread_rng());
+        let public = PublicKey::from_secret_key(&secret);
+
+        let public2 = PublicKey::parse(&public.serialize()).unwrap();
+        let public3 = PublicKey::parse_compressed(&public.serialize_compressed()).unwrap();
+
+        // Reflexivity
+        assert_eq!(public, public);
+        assert_eq!(public2, public2);
+        assert_eq!(public3, public3);
+
+        // Symmetry
+        assert_eq!(public2, public);
+        assert_eq!(public, public2);
+        assert_eq!(public2, public3);
+        assert_eq!(public3, public2);
+
+        // Transitivity
+        assert_eq!(public, public3);
+        assert_eq!(public3, public);
+    }
+}


### PR DESCRIPTION
It is currently assumed that `self` in the `PartialEq::eq` implementation of `Field` always has a magnitude of 1, otherwise triggering an assertion in debug mode or (wrongly) operating with `m = 1` in release mode within `Field::neg_in_place` in the context of comparing public keys. In practice, that means equality of public keys can fail to be symmetric.

In particular, the magnitude of the `y` coordinate of a public key can be `2` after serializing and deserializing it in compressed form, since if the `y` bit is odd, there is another negation in
`Affine::set_xo_var` (called from `PublicKey::parse_compressed`) which increases the magnitude.

This is addressed here by using the current (assumed to be valid) `magnitude` of the field element being negated as the maximum magnitude in `Field::neg_in_place` in the context of the `PartialOrd` impl. The reasoning being that the `PartialOrd` impl should work for elements with any magnitude.

I should mention that I'm really not familiar with secp256k1 in general and the use of the `magnitude` in the implementation in particular and why "maximum magnitudes" are taken as arguments by some functions - my rough understanding is only that it is a measure of "distance" of an element from some canonical ("normalized") representative in the same equivalence class, possibly primarily as an optimisation to avoid "normalizing" elements after every operation? In any case, the problem is easily triggered by the tests I added in this PR for the equality properties (across serialize/parse boundaries). Admittedly I could not get a failing test in release mode with randomized keys where the debug assertions are not present, so maybe this is not actually a problem for release builds but I'm unable to judge.

The problem was originally observed in https://github.com/libp2p/rust-libp2p/issues/1361 in the context of comparing secp256k1 public keys after serialising/parsing in compressed form.