### PR TITLE
Add LowerHex impl for SecretKey and Scalar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ crunchy = "0.2"
 secp256k1-test = "0.7"
 clear_on_drop = "0.2"
 rand-test = { package = "rand", version = "0.4" }
+hex-literal = "0.2.1"
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,6 +375,14 @@ impl Drop for SecretKey {
     }
 }
 
+impl core::fmt::LowerHex for SecretKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let scalar: Scalar = self.clone().into();
+
+        write!(f, "{:x}", scalar)
+    }
+}
+
 impl Signature {
     pub fn parse(p: &[u8; util::SIGNATURE_SIZE]) -> Signature {
         let mut r = Scalar::default();
@@ -638,4 +646,20 @@ pub fn sign(message: &Message, seckey: &SecretKey) -> (Signature, RecoveryId) {
         r: sigr,
         s: sigs,
     }, RecoveryId(recid))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::SecretKey;
+    use hex_literal::hex;
+
+    #[test]
+    fn secret_key_inverse_is_sane() {
+        let sk = SecretKey::parse(&[1; 32]).unwrap();
+        let inv = sk.inv();
+        let invinv = inv.inv();
+        assert_eq!(sk, invinv);
+        // Check that the inverse of `[1; 32]` is same as rust-secp256k1
+        assert_eq!(inv, SecretKey::parse(&hex!("1536f1d756d1abf83aaf173bc5ee3fc487c93010f18624d80bd6d4038fadd59e")).unwrap())
+    }
 }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -935,3 +935,14 @@ impl<'a> Neg for &'a Scalar {
         -value
     }
 }
+
+impl core::fmt::LowerHex for Scalar {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        for word in &self.0[..] {
+            for byte in word.to_be_bytes().iter() {
+                write!(f, "{:02x}", byte)?;
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
…and add a test to check that `inv()` works and that we match `rust-secp256k1`.