### PR TITLE
Remove Eq derive for Jacobian for now

### DIFF
--- a/core/src/group.rs
+++ b/core/src/group.rs
@@ -8,7 +8,7 @@ pub struct Affine {
     pub infinity: bool,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone)]
 /// A group element of the secp256k1 curve, in jacobian coordinates.
 pub struct Jacobian {
     pub x: Field,


### PR DESCRIPTION
This removes the derive of `Eq` on `Jacobian`. It is reported in #42 that it just doesn't work. Jacobian has a scale factor `z`, where values in Affine would be `(x / z^2, y / z^3)`. If `z` is different, it may represent the same value with different `x`s and `y`s.

A proper `Eq` implementation in Jacobian may just be converting it to Affine and them do the comparison, but that is not cheap. Unless I figured out a better way, making the conversion explicit for library users, by just removing the `Eq` derive in Jacobian, may be the better idea.