### PR TITLE
Fix Error re-export

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@ use typenum::U32;
 use crate::{
     curve::{Affine, ECMultContext, ECMultGenContext, Field, Jacobian, Scalar},
     util::{self, Decoder, SignatureArray},
-    Error,
 };
 
 #[cfg(feature = "static-context")]


### PR DESCRIPTION
`pub use libsecp256k1_core::*;` already pulls `Error` into scope, therefore private `use` overshadows the public one and kills re-export.