### PR TITLE
Use rust-secp256k1's rand re-export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,8 @@ typenum = { version = "1.12", optional = true }
 serde = { version = "1.0.104", features = ["derive"], default-features = false }
 
 [dev-dependencies]
-secp256k1-test = { package = "secp256k1", version = "0.17", features = ["rand", "recovery"] }
+secp256k1-test = { package = "secp256k1", version = "0.17", features = ["rand-std", "recovery"] }
 clear_on_drop = "0.2"
-rand-test = { package = "rand", version = "0.6" }
 serde_json = "1.0"
 hex-literal = "0.2.1"
 

--- a/benches/public_key.rs
+++ b/benches/public_key.rs
@@ -3,8 +3,7 @@
 extern crate test;
 
 use libsecp256k1::PublicKey;
-use rand_test::thread_rng;
-use secp256k1_test::Secp256k1;
+use secp256k1_test::{rand::thread_rng, Secp256k1};
 use test::Bencher;
 
 #[bench]

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -4,8 +4,7 @@ extern crate test;
 
 use arrayref::array_ref;
 use libsecp256k1::{sign, Message, SecretKey};
-use rand_test::thread_rng;
-use secp256k1_test::Secp256k1;
+use secp256k1_test::{rand::thread_rng, Secp256k1};
 use test::Bencher;
 
 #[bench]

--- a/benches/signature.rs
+++ b/benches/signature.rs
@@ -3,8 +3,7 @@
 extern crate test;
 
 use libsecp256k1::Signature;
-use rand_test::thread_rng;
-use secp256k1_test::{Message as SecpMessage, Secp256k1};
+use secp256k1_test::{rand::thread_rng, Message as SecpMessage, Secp256k1};
 use test::Bencher;
 
 #[bench]

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -1,16 +1,16 @@
 use libsecp256k1::*;
-use rand_test::thread_rng;
 use secp256k1_test::{
-    key, Error as SecpError, Message as SecpMessage, Secp256k1, Signature as SecpSignature,
+    key, rand::thread_rng, Error as SecpError, Message as SecpMessage, Secp256k1,
+    Signature as SecpSignature,
 };
 
 #[cfg(feature = "hmac")]
 mod signatures {
     use crate::{recover, sign, verify, Message, PublicKey, SecretKey, SharedSecret, Signature};
-    use rand_test::thread_rng;
     use secp256k1_test::{
         ecdh::SharedSecret as SecpSharedSecret,
         key,
+        rand::thread_rng,
         recovery::{
             RecoverableSignature as SecpRecoverableSignature, RecoveryId as SecpRecoveryId,
         },


### PR DESCRIPTION
More clarity in `Cargo.toml`, less breakage when `rust-secp256k1` bumps its own rand dependency.