### PR TITLE
Drop zeroization, impl Copy for everything

### DIFF
--- a/core/src/ecdh.rs
+++ b/core/src/ecdh.rs
@@ -13,8 +13,8 @@ impl ECMultContext {
     ) -> Option<GenericArray<u8, D::OutputSize>> {
         let mut digest: D = Default::default();
 
-        let mut pt = point.clone();
-        let s = scalar.clone();
+        let mut pt = *point;
+        let s = *scalar;
 
         if s.is_zero() {
             return None;

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Error {
     InvalidSignature,
     InvalidPublicKey,

--- a/core/src/field.rs
+++ b/core/src/field.rs
@@ -9,7 +9,7 @@ macro_rules! debug_assert_bits {
     };
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 /// Field element for secp256k1.
 pub struct Field {
     /// Store representation of X.
@@ -1470,55 +1470,55 @@ impl Field {
         let mut x3 = x2.sqr();
         x3 *= self;
 
-        let mut x6 = x3.clone();
+        let mut x6 = x3;
         for _ in 0..3 {
             x6 = x6.sqr();
         }
         x6 *= &x3;
 
-        let mut x9 = x6.clone();
+        let mut x9 = x6;
         for _ in 0..3 {
             x9 = x9.sqr();
         }
         x9 *= &x3;
 
-        let mut x11 = x9.clone();
+        let mut x11 = x9;
         for _ in 0..2 {
             x11 = x11.sqr();
         }
         x11 *= &x2;
 
-        let mut x22 = x11.clone();
+        let mut x22 = x11;
         for _ in 0..11 {
             x22 = x22.sqr();
         }
         x22 *= &x11;
 
-        let mut x44 = x22.clone();
+        let mut x44 = x22;
         for _ in 0..22 {
             x44 = x44.sqr();
         }
         x44 *= &x22;
 
-        let mut x88 = x44.clone();
+        let mut x88 = x44;
         for _ in 0..44 {
             x88 = x88.sqr();
         }
         x88 *= &x44;
 
-        let mut x176 = x88.clone();
+        let mut x176 = x88;
         for _ in 0..88 {
             x176 = x176.sqr();
         }
         x176 *= &x88;
 
-        let mut x220 = x176.clone();
+        let mut x220 = x176;
         for _ in 0..44 {
             x220 = x220.sqr();
         }
         x220 *= &x44;
 
-        let mut x223 = x220.clone();
+        let mut x223 = x220;
         for _ in 0..3 {
             x223 = x223.sqr();
         }
@@ -1550,61 +1550,61 @@ impl Field {
         let mut x3 = x2.sqr();
         x3 *= self;
 
-        let mut x6 = x3.clone();
+        let mut x6 = x3;
         for _ in 0..3 {
             x6 = x6.sqr();
         }
         x6 *= &x3;
 
-        let mut x9 = x6.clone();
+        let mut x9 = x6;
         for _ in 0..3 {
             x9 = x9.sqr();
         }
         x9 *= &x3;
 
-        let mut x11 = x9.clone();
+        let mut x11 = x9;
         for _ in 0..2 {
             x11 = x11.sqr();
         }
         x11 *= &x2;
 
-        let mut x22 = x11.clone();
+        let mut x22 = x11;
         for _ in 0..11 {
             x22 = x22.sqr();
         }
         x22 *= &x11;
 
-        let mut x44 = x22.clone();
+        let mut x44 = x22;
         for _ in 0..22 {
             x44 = x44.sqr();
         }
         x44 *= &x22;
 
-        let mut x88 = x44.clone();
+        let mut x88 = x44;
         for _ in 0..44 {
             x88 = x88.sqr();
         }
         x88 *= &x44;
 
-        let mut x176 = x88.clone();
+        let mut x176 = x88;
         for _ in 0..88 {
             x176 = x176.sqr();
         }
         x176 *= &x88;
 
-        let mut x220 = x176.clone();
+        let mut x220 = x176;
         for _ in 0..44 {
             x220 = x220.sqr();
         }
         x220 *= &x44;
 
-        let mut x223 = x220.clone();
+        let mut x223 = x220;
         for _ in 0..3 {
             x223 = x223.sqr();
         }
         x223 *= &x3;
 
-        let mut t1 = x223.clone();
+        let mut t1 = x223;
         for _ in 0..23 {
             t1 = t1.sqr();
         }
@@ -1675,7 +1675,7 @@ impl Default for Field {
 impl Add<Field> for Field {
     type Output = Field;
     fn add(self, other: Field) -> Field {
-        let mut ret = self.clone();
+        let mut ret = self;
         ret.add_assign(&other);
         ret
     }
@@ -1684,7 +1684,7 @@ impl Add<Field> for Field {
 impl<'a, 'b> Add<&'a Field> for &'b Field {
     type Output = Field;
     fn add(self, other: &'a Field) -> Field {
-        let mut ret = self.clone();
+        let mut ret = *self;
         ret.add_assign(other);
         ret
     }
@@ -1769,7 +1769,7 @@ impl PartialOrd for Field {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Compact field element storage.
 pub struct FieldStorage(pub [u32; 8]);
 

--- a/core/src/group.rs
+++ b/core/src/group.rs
@@ -1,6 +1,6 @@
 use crate::field::{Field, FieldStorage};
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// A group element of the secp256k1 curve, in affine coordinates.
 pub struct Affine {
     pub x: Field,
@@ -8,7 +8,7 @@ pub struct Affine {
     pub infinity: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 /// A group element of the secp256k1 curve, in jacobian coordinates.
 pub struct Jacobian {
     pub x: Field,
@@ -17,7 +17,7 @@ pub struct Jacobian {
     pub infinity: bool,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Affine coordinate group element compact storage.
 pub struct AffineStorage {
     pub x: FieldStorage,
@@ -94,8 +94,8 @@ impl Affine {
     /// coordinates.
     pub fn set_xy(&mut self, x: &Field, y: &Field) {
         self.infinity = false;
-        self.x = x.clone();
-        self.y = y.clone();
+        self.x = *x;
+        self.y = *y;
     }
 
     /// Set a group element (affine) equal to the point with the given
@@ -103,13 +103,13 @@ impl Affine {
     /// modulo p. The return value is true iff a coordinate with the
     /// given X coordinate exists.
     pub fn set_xquad(&mut self, x: &Field) -> bool {
-        self.x = x.clone();
+        self.x = *x;
         let x2 = x.sqr();
-        let x3 = x * &x2;
+        let x3 = *x * x2;
         self.infinity = false;
         let mut c = Field::default();
         c.set_int(CURVE_B);
-        c += &x3;
+        c += x3;
         let (v, ret) = c.sqrt();
         self.y = v;
         ret
@@ -150,7 +150,7 @@ impl Affine {
     }
 
     pub fn neg_in_place(&mut self, other: &Affine) {
-        *self = other.clone();
+        *self = *other;
         self.y.normalize_weak();
         self.y = self.y.neg(1);
     }
@@ -165,12 +165,12 @@ impl Affine {
     /// jacobian coordinates.
     pub fn set_gej(&mut self, a: &Jacobian) {
         self.infinity = a.infinity;
-        let mut a = a.clone();
+        let mut a = *a;
         a.z = a.z.inv();
         let z2 = a.z.sqr();
-        let z3 = &a.z * &z2;
-        a.x *= &z2;
-        a.y *= &z3;
+        let z3 = a.z * z2;
+        a.x *= z2;
+        a.y *= z3;
         a.z.set_int(1);
         self.x = a.x;
         self.y = a.y;
@@ -183,14 +183,14 @@ impl Affine {
     }
 
     pub fn set_gej_var(&mut self, a: &Jacobian) {
-        let mut a = a.clone();
+        let mut a = *a;
         self.infinity = a.infinity;
         if a.is_infinity() {
             return;
         }
         a.z = a.z.inv_var();
         let z2 = a.z.sqr();
-        let z3 = &a.z * &z2;
+        let z3 = a.z * z2;
         a.x *= &z2;
         a.y *= &z3;
         a.z.set_int(1);
@@ -200,9 +200,9 @@ impl Affine {
 
     pub fn set_gej_zinv(&mut self, a: &Jacobian, zi: &Field) {
         let zi2 = zi.sqr();
-        let zi3 = &zi2 * &zi;
-        self.x = &a.x * &zi2;
-        self.y = &a.y * &zi3;
+        let zi3 = zi2 * *zi;
+        self.x = a.x * zi2;
+        self.y = a.y * zi3;
         self.infinity = a.infinity;
     }
 
@@ -239,15 +239,15 @@ pub fn globalz_set_table_gej(r: &mut [Affine], globalz: &mut Field, a: &[Jacobia
     let mut zs: Field;
 
     if r.len() > 0 {
-        r[i].x = a[i].x.clone();
-        r[i].y = a[i].y.clone();
-        *globalz = a[i].z.clone();
+        r[i].x = a[i].x;
+        r[i].y = a[i].y;
+        *globalz = a[i].z;
         r[i].infinity = false;
-        zs = zr[i].clone();
+        zs = zr[i];
 
         while i > 0 {
             if i != r.len() - 1 {
-                zs *= &zr[i];
+                zs *= zr[i];
             }
             i -= 1;
             r[i].set_gej_zinv(&a[i], &zs);
@@ -278,8 +278,8 @@ impl Jacobian {
     /// in affine coordinates.
     pub fn set_ge(&mut self, a: &Affine) {
         self.infinity = a.infinity;
-        self.x = a.x.clone();
-        self.y = a.y.clone();
+        self.x = a.x;
+        self.y = a.y;
         self.z.set_int(1);
     }
 
@@ -294,7 +294,7 @@ impl Jacobian {
         debug_assert!(!self.is_infinity());
         let mut r = self.z.sqr();
         r *= x;
-        let mut r2 = self.x.clone();
+        let mut r2 = self.x;
         r2.normalize_weak();
         return r.eq_var(&r2);
     }
@@ -303,9 +303,9 @@ impl Jacobian {
     /// axis).
     pub fn neg_in_place(&mut self, a: &Jacobian) {
         self.infinity = a.infinity;
-        self.x = a.x.clone();
-        self.y = a.y.clone();
-        self.z = a.z.clone();
+        self.x = a.x;
+        self.y = a.y;
+        self.z = a.z;
         self.y.normalize_weak();
         self.y = self.y.neg(1);
     }
@@ -327,7 +327,7 @@ impl Jacobian {
             return false;
         }
 
-        let yz = &self.y * &self.z;
+        let yz = self.y * self.z;
         return yz.is_quad_var();
     }
 
@@ -351,12 +351,12 @@ impl Jacobian {
         }
 
         if let Some(rzr) = rzr {
-            *rzr = a.y.clone();
+            *rzr = a.y;
             rzr.normalize_weak();
             rzr.mul_int(2);
         }
 
-        self.z = &a.z * &a.y;
+        self.z = a.z * a.y;
         self.z.mul_int(2);
         let mut t1 = a.x.sqr();
         t1.mul_int(3);
@@ -366,16 +366,16 @@ impl Jacobian {
         let mut t4 = t3.sqr();
         t4.mul_int(2);
         t3 *= &a.x;
-        self.x = t3.clone();
+        self.x = t3;
         self.x.mul_int(4);
         self.x = self.x.neg(4);
         self.x += &t2;
         t2 = t2.neg(1);
         t3.mul_int(6);
         t3 += &t2;
-        self.y = &t1 * &t3;
+        self.y = t1 * t3;
         t2 = t4.neg(2);
-        self.y += &t2;
+        self.y += t2;
     }
 
     pub fn double_var(&self, rzr: Option<&mut Field>) -> Jacobian {
@@ -389,30 +389,30 @@ impl Jacobian {
     pub fn add_var_in_place(&mut self, a: &Jacobian, b: &Jacobian, rzr: Option<&mut Field>) {
         if a.is_infinity() {
             debug_assert!(rzr.is_none());
-            *self = b.clone();
+            *self = *b;
             return;
         }
         if b.is_infinity() {
             if let Some(rzr) = rzr {
                 rzr.set_int(1);
             }
-            *self = a.clone();
+            *self = *a;
             return;
         }
 
         self.infinity = false;
         let z22 = b.z.sqr();
         let z12 = a.z.sqr();
-        let u1 = &a.x * &z22;
-        let u2 = &b.x * &z12;
-        let mut s1 = &a.y * &z22;
-        s1 *= &b.z;
-        let mut s2 = &b.y * &z12;
-        s2 *= &a.z;
+        let u1 = a.x * z22;
+        let u2 = b.x * z12;
+        let mut s1 = a.y * z22;
+        s1 *= b.z;
+        let mut s2 = b.y * z12;
+        s2 *= a.z;
         let mut h = u1.neg(1);
-        h += &u2;
+        h += u2;
         let mut i = s1.neg(1);
-        i += &s2;
+        i += s2;
         if h.normalizes_to_zero_var() {
             if i.normalizes_to_zero_var() {
                 self.double_var_in_place(a, rzr);
@@ -426,24 +426,24 @@ impl Jacobian {
         }
         let i2 = i.sqr();
         let h2 = h.sqr();
-        let mut h3 = &h * &h2;
-        h *= &b.z;
+        let mut h3 = h * h2;
+        h *= b.z;
         if let Some(rzr) = rzr {
-            *rzr = h.clone();
+            *rzr = h;
         }
-        self.z = &a.z * &h;
-        let t = &u1 * &h2;
-        self.x = t.clone();
+        self.z = a.z * h;
+        let t = u1 * h2;
+        self.x = t;
         self.x.mul_int(2);
-        self.x += &h3;
+        self.x += h3;
         self.x = self.x.neg(3);
-        self.x += &i2;
+        self.x += i2;
         self.y = self.x.neg(5);
-        self.y += &t;
-        self.y *= &i;
-        h3 *= &s1;
+        self.y += t;
+        self.y *= i;
+        h3 *= s1;
         h3 = h3.neg(1);
-        self.y += &h3;
+        self.y += h3;
     }
 
     pub fn add_var(&self, b: &Jacobian, rzr: Option<&mut Field>) -> Jacobian {
@@ -460,36 +460,36 @@ impl Jacobian {
         debug_assert!(!b.infinity);
 
         let zz = a.z.sqr();
-        let mut u1 = a.x.clone();
+        let mut u1 = a.x;
         u1.normalize_weak();
-        let u2 = &b.x * &zz;
-        let mut s1 = a.y.clone();
+        let u2 = b.x * zz;
+        let mut s1 = a.y;
         s1.normalize_weak();
-        let mut s2 = &b.y * &zz;
-        s2 *= &a.z;
-        let mut t = u1.clone();
-        t += &u2;
-        let mut m = s1.clone();
-        m += &s2;
+        let mut s2 = b.y * zz;
+        s2 *= a.z;
+        let mut t = u1;
+        t += u2;
+        let mut m = s1;
+        m += s2;
         let mut rr = t.sqr();
         let mut m_alt = u2.neg(1);
-        let tt = &u1 * &m_alt;
-        rr += &tt;
+        let tt = u1 * m_alt;
+        rr += tt;
         let degenerate = m.normalizes_to_zero() && rr.normalizes_to_zero();
-        let mut rr_alt = s1.clone();
+        let mut rr_alt = s1;
         rr_alt.mul_int(2);
-        m_alt += &u1;
+        m_alt += u1;
 
         rr_alt.cmov(&rr, !degenerate);
         m_alt.cmov(&m, !degenerate);
 
         let mut n = m_alt.sqr();
-        let mut q = &n * &t;
+        let mut q = n * t;
 
         n = n.sqr();
         n.cmov(&m, degenerate);
         t = rr_alt.sqr();
-        self.z = &a.z * &m_alt;
+        self.z = a.z * m_alt;
         let infinity = {
             let p = self.z.normalizes_to_zero();
             let q = a.infinity;
@@ -503,13 +503,13 @@ impl Jacobian {
         };
         self.z.mul_int(2);
         q = q.neg(1);
-        t += &q;
+        t += q;
         t.normalize_weak();
-        self.x = t.clone();
+        self.x = t;
         t.mul_int(2);
-        t += &q;
-        t *= &rr_alt;
-        t += &n;
+        t += q;
+        t *= rr_alt;
+        t += n;
         self.y = t.neg(3);
         self.y.normalize_weak();
         self.x.mul_int(4);
@@ -543,23 +543,23 @@ impl Jacobian {
             if let Some(rzr) = rzr {
                 rzr.set_int(1);
             }
-            *self = a.clone();
+            *self = *a;
             return;
         }
         self.infinity = false;
 
         let z12 = a.z.sqr();
-        let mut u1 = a.x.clone();
+        let mut u1 = a.x;
         u1.normalize_weak();
-        let u2 = &b.x * &z12;
-        let mut s1 = a.y.clone();
+        let u2 = b.x * z12;
+        let mut s1 = a.y;
         s1.normalize_weak();
-        let mut s2 = &b.y * &z12;
-        s2 *= &a.z;
+        let mut s2 = b.y * z12;
+        s2 *= a.z;
         let mut h = u1.neg(1);
-        h += &u2;
+        h += u2;
         let mut i = s1.neg(1);
-        i += &s2;
+        i += s2;
         if h.normalizes_to_zero_var() {
             if i.normalizes_to_zero_var() {
                 self.double_var_in_place(a, rzr);
@@ -573,23 +573,23 @@ impl Jacobian {
         }
         let i2 = i.sqr();
         let h2 = h.sqr();
-        let mut h3 = &h * &h2;
+        let mut h3 = h * h2;
         if let Some(rzr) = rzr {
-            *rzr = h.clone();
+            *rzr = h;
         }
-        self.z = &a.z * &h;
-        let t = &u1 * &h2;
-        self.x = t.clone();
+        self.z = a.z * h;
+        let t = u1 * h2;
+        self.x = t;
         self.x.mul_int(2);
-        self.x += &h3;
+        self.x += h3;
         self.x = self.x.neg(3);
-        self.x += &i2;
+        self.x += i2;
         self.y = self.x.neg(5);
-        self.y += &t;
-        self.y *= &i;
-        h3 *= &s1;
+        self.y += t;
+        self.y *= i;
+        h3 *= s1;
         h3 = h3.neg(1);
-        self.y += &h3;
+        self.y += h3;
     }
 
     pub fn add_ge_var(&self, b: &Affine, rzr: Option<&mut Field>) -> Jacobian {
@@ -602,28 +602,28 @@ impl Jacobian {
     /// coordinate passed as bzinv).
     pub fn add_zinv_var_in_place(&mut self, a: &Jacobian, b: &Affine, bzinv: &Field) {
         if b.is_infinity() {
-            *self = a.clone();
+            *self = *a;
             return;
         }
         if a.is_infinity() {
             self.infinity = b.infinity;
             let bzinv2 = bzinv.sqr();
             let bzinv3 = &bzinv2 * bzinv;
-            self.x = &b.x * &bzinv2;
-            self.y = &b.y * &bzinv3;
+            self.x = b.x * bzinv2;
+            self.y = b.y * bzinv3;
             self.z.set_int(1);
             return;
         }
         self.infinity = false;
 
-        let az = &a.z * &bzinv;
+        let az = a.z * *bzinv;
         let z12 = az.sqr();
-        let mut u1 = a.x.clone();
+        let mut u1 = a.x;
         u1.normalize_weak();
-        let u2 = &b.x * &z12;
-        let mut s1 = a.y.clone();
+        let u2 = b.x * z12;
+        let mut s1 = a.y;
         s1.normalize_weak();
-        let mut s2 = &b.y * &z12;
+        let mut s2 = b.y * z12;
         s2 *= &az;
         let mut h = u1.neg(1);
         h += &u2;
@@ -639,21 +639,21 @@ impl Jacobian {
         }
         let i2 = i.sqr();
         let h2 = h.sqr();
-        let mut h3 = &h * &h2;
-        self.z = a.z.clone();
-        self.z *= &h;
-        let t = &u1 * &h2;
-        self.x = t.clone();
+        let mut h3 = h * h2;
+        self.z = a.z;
+        self.z *= h;
+        let t = u1 * h2;
+        self.x = t;
         self.x.mul_int(2);
-        self.x += &h3;
+        self.x += h3;
         self.x = self.x.neg(3);
-        self.x += &i2;
+        self.x += i2;
         self.y = self.x.neg(5);
-        self.y += &t;
-        self.y *= &i;
-        h3 *= &s1;
+        self.y += t;
+        self.y *= i;
+        h3 *= s1;
         h3 = h3.neg(1);
-        self.y += &h3;
+        self.y += h3;
     }
 
     pub fn add_zinv_var(&mut self, b: &Affine, bzinv: &Field) -> Jacobian {

--- a/core/src/scalar.rs
+++ b/core/src/scalar.rs
@@ -21,15 +21,9 @@ const SECP256K1_N_H_5: u32 = 0xFFFFFFFF;
 const SECP256K1_N_H_6: u32 = 0xFFFFFFFF;
 const SECP256K1_N_H_7: u32 = 0x7FFFFFFF;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// A 256-bit scalar value.
 pub struct Scalar(pub [u32; 8]);
-
-impl Drop for Scalar {
-    fn drop(&mut self) {
-        self.clear();
-    }
-}
 
 impl Scalar {
     /// Clear a scalar to prevent the leak of sensitive data.
@@ -773,12 +767,12 @@ impl Scalar {
 
     pub fn inv_in_place(&mut self, x: &Scalar) {
         let u2 = x.sqr();
-        let x2 = &u2 * x;
-        let u5 = &u2 * &x2;
-        let x3 = &u5 * &u2;
-        let u9 = &x3 * &u2;
-        let u11 = &u9 * &u2;
-        let u13 = &u11 * &u2;
+        let x2 = u2 * *x;
+        let u5 = u2 * x2;
+        let x3 = u5 * u2;
+        let u9 = x3 * u2;
+        let u11 = u9 * u2;
+        let u13 = u11 * u2;
 
         let mut x6 = u13.sqr();
         x6 = x6.sqr();
@@ -914,7 +908,7 @@ impl Scalar {
         for _ in 0..8 {
             t = t.sqr();
         }
-        *self = &t * &x6;
+        *self = t * x6;
     }
 
     pub fn inv(&self) -> Scalar {
@@ -949,7 +943,7 @@ impl Add<Scalar> for Scalar {
 impl<'a, 'b> Add<&'a Scalar> for &'b Scalar {
     type Output = Scalar;
     fn add(self, other: &'a Scalar) -> Scalar {
-        let mut ret = self.clone();
+        let mut ret = *self;
         ret.add_assign(other);
         ret
     }
@@ -1021,7 +1015,7 @@ impl Neg for Scalar {
 impl<'a> Neg for &'a Scalar {
     type Output = Scalar;
     fn neg(self) -> Scalar {
-        let value = self.clone();
+        let value = *self;
         -value
     }
 }

--- a/gen/genmult/src/lib.rs
+++ b/gen/genmult/src/lib.rs
@@ -12,7 +12,7 @@ pub fn generate_to(file: &mut File) -> Result<(), Error> {
     for j in 0..64 {
         file.write_fmt(format_args!("    ["))?;
         for i in 0..16 {
-            let pg: AffineStorage = prec[j][i].clone().into();
+            let pg: AffineStorage = prec[j][i].into();
             file.write_fmt(format_args!(
                 "        crate::curve::AffineStorage::new(crate::curve::FieldStorage::new({}, {}, {}, {}, {}, {}, {}, {}), crate::curve::FieldStorage::new({}, {}, {}, {}, {}, {}, {}, {})),",
                 pg.x.0[7], pg.x.0[6], pg.x.0[5], pg.x.0[4], pg.x.0[3], pg.x.0[2], pg.x.0[1], pg.x.0[0],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,9 @@
     unreachable_code,
     unused_parens
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
-extern crate alloc;
 
 pub use libsecp256k1_core::*;
 
-use alloc::vec;
 use arrayref::{array_mut_ref, array_ref};
 use core::convert::TryFrom;
 use digest::{generic_array::GenericArray, Digest};
@@ -51,13 +48,13 @@ pub static ECMULT_CONTEXT: ECMultContext =
 pub static ECMULT_GEN_CONTEXT: ECMultGenContext =
     unsafe { ECMultGenContext::new_from_raw(include!(concat!(env!("OUT_DIR"), "/const_gen.rs"))) };
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Public key on a secp256k1 curve.
 pub struct PublicKey(Affine);
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Secret key (256-bit) on a secp256k1 curve.
 pub struct SecretKey(Scalar);
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// An ECDSA signature.
 pub struct Signature {
     pub r: Scalar,
@@ -66,12 +63,19 @@ pub struct Signature {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Tag used for public key recovery from signatures.
 pub struct RecoveryId(u8);
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Hashed message input to an ECDSA signature.
 pub struct Message(pub Scalar);
 #[derive(Debug, Clone, Eq, PartialEq)]
 /// Shared secret using ECDH.
 pub struct SharedSecret<D: Digest>(GenericArray<u8, D::OutputSize>);
+
+impl<D> Copy for SharedSecret<D>
+where
+    D: Copy + Digest,
+    GenericArray<u8, D::OutputSize>: Copy,
+{
+}
 
 /// Format for public key parsing.
 pub enum PublicKeyFormat {
@@ -199,7 +203,7 @@ impl PublicKey {
         debug_assert!(!self.0.is_infinity());
 
         let mut ret = [0u8; 65];
-        let mut elem = self.0.clone();
+        let mut elem = self.0;
 
         elem.x.normalize_var();
         elem.y.normalize_var();
@@ -216,7 +220,7 @@ impl PublicKey {
         debug_assert!(!self.0.is_infinity());
 
         let mut ret = [0u8; 33];
-        let mut elem = self.0.clone();
+        let mut elem = self.0;
 
         elem.x.normalize_var();
         elem.y.normalize_var();
@@ -430,7 +434,7 @@ impl Default for SecretKey {
 
 impl Into<Scalar> for SecretKey {
     fn into(self) -> Scalar {
-        self.0.clone()
+        self.0
     }
 }
 
@@ -446,15 +450,9 @@ impl TryFrom<Scalar> for SecretKey {
     }
 }
 
-impl Drop for SecretKey {
-    fn drop(&mut self) {
-        self.0.clear();
-    }
-}
-
 impl core::fmt::LowerHex for SecretKey {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let scalar: Scalar = self.clone().into();
+        let scalar = self.0;
 
         write!(f, "{:x}", scalar)
     }
@@ -537,7 +535,7 @@ impl Signature {
     /// which ensures that the s value lies in the lower half of its range.
     pub fn normalize_s(&mut self) {
         if self.s.is_high() {
-            self.s = -self.s.clone();
+            self.s = -self.s;
         }
     }
 
@@ -670,15 +668,6 @@ impl<D: Digest + Default> SharedSecret<D> {
 impl<D: Digest> AsRef<[u8]> for SharedSecret<D> {
     fn as_ref(&self) -> &[u8] {
         &self.0.as_ref()
-    }
-}
-
-impl<D: Digest> Drop for SharedSecret<D> {
-    fn drop(&mut self) {
-        let zero_array = GenericArray::clone_from_slice(&vec![0; D::output_size()]);
-        unsafe {
-            core::ptr::write_volatile(&mut self.0, zero_array);
-        }
     }
 }
 

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -190,13 +190,13 @@ fn test_verify() {
 
     secp256k1.verify(&message, &signature, &pubkey).unwrap();
     assert!(verify(&ctx_message, &ctx_sig, &ctx_pubkey));
-    let mut f_ctx_sig = ctx_sig.clone();
+    let mut f_ctx_sig = ctx_sig;
     f_ctx_sig.r.set_int(0);
     if f_ctx_sig.r != ctx_sig.r {
         assert!(!ECMULT_CONTEXT.verify_raw(
             &f_ctx_sig.r,
             &ctx_sig.s,
-            &ctx_pubkey.clone().into(),
+            &ctx_pubkey.into(),
             &ctx_message.0
         ));
     }
@@ -205,7 +205,7 @@ fn test_verify() {
         assert!(!ECMULT_CONTEXT.verify_raw(
             &f_ctx_sig.r,
             &ctx_sig.s,
-            &ctx_pubkey.clone().into(),
+            &ctx_pubkey.into(),
             &ctx_message.0
         ));
     }


### PR DESCRIPTION
As shown by https://github.com/paritytech/parity-common/pull/400 you can't have reliable memory erasure without keeping it on the heap. Since this is less than acceptable here, we might as well drop zeroization altogether and implement `Copy` for all types.

This is a conservative PR. Another one that breaks the APIs by replacing reference arguments with values will follow.