### PR TITLE
Copy-based API

### DIFF
--- a/benches/public_key.rs
+++ b/benches/public_key.rs
@@ -15,7 +15,7 @@ fn bench_public_key_parse(b: &mut Bencher) {
     let mut pubkey_a = [0u8; 65];
     pubkey_a[0..65].copy_from_slice(&pubkey_arr[0..65]);
     b.iter(|| {
-        let _pubkey = PublicKey::parse(&pubkey_a).unwrap();
+        let _pubkey = PublicKey::parse(pubkey_a).unwrap();
     });
 }
 
@@ -27,7 +27,7 @@ fn bench_public_key_serialize(b: &mut Bencher) {
     assert!(pubkey_arr.len() == 65);
     let mut pubkey_a = [0u8; 65];
     pubkey_a[0..65].copy_from_slice(&pubkey_arr[0..65]);
-    let pubkey = PublicKey::parse(&pubkey_a).unwrap();
+    let pubkey = PublicKey::parse(pubkey_a).unwrap();
     b.iter(|| {
         let _serialized = pubkey.serialize();
     });
@@ -41,7 +41,7 @@ fn bench_public_key_serialize_compressed(b: &mut Bencher) {
     assert!(pubkey_arr.len() == 65);
     let mut pubkey_a = [0u8; 65];
     pubkey_a[0..65].copy_from_slice(&pubkey_arr[0..65]);
-    let pubkey = PublicKey::parse(&pubkey_a).unwrap();
+    let pubkey = PublicKey::parse(pubkey_a).unwrap();
     b.iter(|| {
         let _serialized = pubkey.serialize_compressed();
     });

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -10,11 +10,11 @@ use test::Bencher;
 #[bench]
 fn bench_sign_message(b: &mut Bencher) {
     let secp256k1 = Secp256k1::new();
-    let message = Message::parse(&[5u8; 32]);
+    let message = Message::parse([5u8; 32]);
     let (secp_privkey, _) = secp256k1.generate_keypair(&mut thread_rng());
-    let seckey = SecretKey::parse(array_ref!(secp_privkey, 0, 32)).unwrap();
+    let seckey = SecretKey::parse(*array_ref!(secp_privkey, 0, 32)).unwrap();
 
     b.iter(|| {
-        let _ = sign(&message, &seckey);
+        let _ = sign(message, seckey);
     });
 }

--- a/benches/signature.rs
+++ b/benches/signature.rs
@@ -19,7 +19,7 @@ fn bench_signature_parse(b: &mut Bencher) {
     signature_a.copy_from_slice(&signature_arr[0..64]);
 
     b.iter(|| {
-        let _signature = Signature::parse(&signature_a);
+        let _signature = Signature::parse(signature_a);
     });
 }
 
@@ -34,7 +34,7 @@ fn bench_signature_serialize(b: &mut Bencher) {
     assert!(signature_arr.len() == 64);
     let mut signature_a = [0u8; 64];
     signature_a.copy_from_slice(&signature_arr[0..64]);
-    let signature = Signature::parse(&signature_a);
+    let signature = Signature::parse(signature_a);
 
     b.iter(|| {
         let _serialized = signature.serialize();

--- a/core/src/der.rs
+++ b/core/src/der.rs
@@ -177,7 +177,7 @@ impl<'a> Decoder<'a> {
             b32[32 - rlen..].copy_from_slice(self.peek_slice(rlen)?);
             self.skip(rlen)?;
 
-            overflow |= bool::from(int.set_b32(&b32));
+            overflow |= bool::from(int.set_b32(b32));
         }
 
         if overflow {
@@ -256,7 +256,7 @@ impl<'a> Decoder<'a> {
             b32[32 - len..].copy_from_slice(&self.peek_slice(len)?);
             self.skip(len)?;
 
-            overflow |= bool::from(int.set_b32(&b32));
+            overflow |= bool::from(int.set_b32(b32));
         }
 
         if overflow {

--- a/core/src/ecdh.rs
+++ b/core/src/ecdh.rs
@@ -8,21 +8,18 @@ use digest::{generic_array::GenericArray, Digest};
 impl ECMultContext {
     pub fn ecdh_raw<D: Digest + Default>(
         &self,
-        point: &Affine,
-        scalar: &Scalar,
+        mut pt: Affine,
+        s: Scalar,
     ) -> Option<GenericArray<u8, D::OutputSize>> {
         let mut digest: D = Default::default();
-
-        let mut pt = *point;
-        let s = *scalar;
 
         if s.is_zero() {
             return None;
         }
 
         let mut res = Jacobian::default();
-        self.ecmult_const(&mut res, &pt, &s);
-        pt.set_gej(&res);
+        self.ecmult_const(&mut res, pt, s);
+        pt.set_gej(res);
 
         pt.x.normalize();
         pt.y.normalize();

--- a/core/src/ecdsa.rs
+++ b/core/src/ecdsa.rs
@@ -13,13 +13,7 @@ const ORDER_AS_FE: Field = Field::new(
 );
 
 impl ECMultContext {
-    pub fn verify_raw(
-        &self,
-        sigr: &Scalar,
-        sigs: &Scalar,
-        pubkey: &Affine,
-        message: &Scalar,
-    ) -> bool {
+    pub fn verify_raw(&self, sigr: Scalar, sigs: Scalar, pubkey: Affine, message: Scalar) -> bool {
         let c;
         let (sn, u1, u2): (Scalar, Scalar, Scalar);
 
@@ -28,28 +22,28 @@ impl ECMultContext {
         }
 
         sn = sigs.inv_var();
-        u1 = &sn * message;
-        u2 = &sn * sigr;
+        u1 = sn * message;
+        u2 = sn * sigr;
         let mut pubkeyj: Jacobian = Jacobian::default();
         pubkeyj.set_ge(pubkey);
         let mut pr: Jacobian = Jacobian::default();
-        self.ecmult(&mut pr, &pubkeyj, &u2, &u1);
+        self.ecmult(&mut pr, pubkeyj, u2, u1);
         if pr.is_infinity() {
             return false;
         }
 
         c = sigr.b32();
         let mut xr: Field = Default::default();
-        let _ = xr.set_b32(&c);
+        let _ = xr.set_b32(c);
 
-        if pr.eq_x_var(&xr) {
+        if pr.eq_x_var(xr) {
             return true;
         }
         if xr >= P_MINUS_ORDER {
             return false;
         }
         xr += ORDER_AS_FE;
-        if pr.eq_x_var(&xr) {
+        if pr.eq_x_var(xr) {
             return true;
         }
         false
@@ -57,10 +51,10 @@ impl ECMultContext {
 
     pub fn recover_raw(
         &self,
-        sigr: &Scalar,
-        sigs: &Scalar,
+        sigr: Scalar,
+        sigs: Scalar,
         rec_id: u8,
-        message: &Scalar,
+        message: Scalar,
     ) -> Result<Affine, Error> {
         debug_assert!(rec_id < 4);
 
@@ -70,7 +64,7 @@ impl ECMultContext {
 
         let brx = sigr.b32();
         let mut fx = Field::default();
-        let overflow = fx.set_b32(&brx);
+        let overflow = fx.set_b32(brx);
         debug_assert!(overflow);
 
         if rec_id & 2 > 0 {
@@ -80,20 +74,20 @@ impl ECMultContext {
             fx += ORDER_AS_FE;
         }
         let mut x = Affine::default();
-        if !x.set_xo_var(&fx, rec_id & 1 > 0) {
+        if !x.set_xo_var(fx, rec_id & 1 > 0) {
             return Err(Error::InvalidSignature);
         }
         let mut xj = Jacobian::default();
-        xj.set_ge(&x);
+        xj.set_ge(x);
         let rn = sigr.inv();
-        let mut u1 = &rn * message;
+        let mut u1 = rn * message;
         u1 = -u1;
-        let u2 = &rn * sigs;
+        let u2 = rn * sigs;
         let mut qj = Jacobian::default();
-        self.ecmult(&mut qj, &xj, &u2, &u1);
+        self.ecmult(&mut qj, xj, u2, u1);
 
         let mut pubkey = Affine::default();
-        pubkey.set_gej_var(&qj);
+        pubkey.set_gej_var(qj);
 
         if pubkey.is_infinity() {
             Err(Error::InvalidSignature)
@@ -106,24 +100,24 @@ impl ECMultContext {
 impl ECMultGenContext {
     pub fn sign_raw(
         &self,
-        seckey: &Scalar,
-        message: &Scalar,
-        nonce: &Scalar,
+        seckey: Scalar,
+        message: Scalar,
+        nonce: Scalar,
     ) -> Result<(Scalar, Scalar, u8), Error> {
         let mut rp = Jacobian::default();
         self.ecmult_gen(&mut rp, nonce);
         let mut r = Affine::default();
-        r.set_gej(&rp);
+        r.set_gej(rp);
         r.x.normalize();
         r.y.normalize();
         let b = r.x.b32();
         let mut sigr = Scalar::default();
-        let overflow = bool::from(sigr.set_b32(&b));
+        let overflow = bool::from(sigr.set_b32(b));
         debug_assert!(!sigr.is_zero());
         debug_assert!(!overflow);
 
         let mut recid = (if overflow { 2 } else { 0 }) | (if r.y.is_odd() { 1 } else { 0 });
-        let mut n = &sigr * seckey;
+        let mut n = sigr * seckey;
         n += message;
         let mut sigs = nonce.inv();
         sigs *= &n;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,6 +31,8 @@ mod ecdh;
 mod ecdsa;
 mod ecmult;
 mod error;
+#[macro_use]
+mod macros;
 mod scalar;
 
 pub use crate::error::Error;

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -1,0 +1,63 @@
+// implements the unary operator "op &T"
+// based on "op T" where T is expected to be `Copy`able
+#[macro_export]
+macro_rules! forward_ref_unop {
+    (impl $imp:ident, $method:ident for $t:ty) => {
+        impl $imp for &$t {
+            type Output = <$t as $imp>::Output;
+
+            #[inline]
+            fn $method(self) -> <$t as $imp>::Output {
+                $imp::$method(*self)
+            }
+        }
+    };
+}
+
+// implements binary operators "&T op U", "T op &U", "&T op &U"
+// based on "T op U" where T and U are expected to be `Copy`able
+#[macro_export]
+macro_rules! forward_ref_binop {
+    (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
+        impl<'a> $imp<$u> for &'a $t {
+            type Output = <$t as $imp<$u>>::Output;
+
+            #[inline]
+            fn $method(self, other: $u) -> <$t as $imp<$u>>::Output {
+                $imp::$method(*self, other)
+            }
+        }
+
+        impl $imp<&$u> for $t {
+            type Output = <$t as $imp<$u>>::Output;
+
+            #[inline]
+            fn $method(self, other: &$u) -> <$t as $imp<$u>>::Output {
+                $imp::$method(self, *other)
+            }
+        }
+
+        impl $imp<&$u> for &$t {
+            type Output = <$t as $imp<$u>>::Output;
+
+            #[inline]
+            fn $method(self, other: &$u) -> <$t as $imp<$u>>::Output {
+                $imp::$method(*self, *other)
+            }
+        }
+    };
+}
+
+// implements "T op= &U", based on "T op= U"
+// where U is expected to be `Copy`able
+#[macro_export]
+macro_rules! forward_ref_op_assign {
+    (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
+        impl $imp<&$u> for $t {
+            #[inline]
+            fn $method(&mut self, other: &$u) {
+                $imp::$method(self, *other);
+            }
+        }
+    };
+}

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -8,8 +8,8 @@ const SERIALIZED_DEBUG_PUBLIC_KEY: &str =
     "\"BBuExVZ7EmRAmV0+1aq6BWXXHhg0YEgZ/5wX9enV3QePcL6vj1iLVBUH/tamQsWrQt/fgSCn9jneUSLUemmo6NE=\"";
 
 fn debug_public_key() -> PublicKey {
-    let skey = SecretKey::parse(&DEBUG_SECRET_KEY).unwrap();
-    PublicKey::from_secret_key(&skey)
+    let skey = SecretKey::parse(DEBUG_SECRET_KEY).unwrap();
+    PublicKey::from_secret_key(skey)
 }
 
 #[test]


### PR DESCRIPTION
This PR simplifies the API by using pass by value for what is essentially a number (e.g. `SecretKey`, `PublicKey` and their inner component math types). Benches did not yield statistically significant performance difference.

I used [unexported macros from core](https://github.com/rust-lang/rust/blob/master/src/libcore/internal_macros.rs) for clean arithmetic ops implementations, they are licensed under Apache-2.0 so we should be fine.