### PR TITLE
Fix no_std build

### DIFF
--- a/benches/signature.rs
+++ b/benches/signature.rs
@@ -19,7 +19,7 @@ fn bench_signature_parse(b: &mut Bencher) {
     signature_a.copy_from_slice(&signature_arr[0..64]);
 
     b.iter(|| {
-        let _signature = Signature::parse(&signature_a);
+        let _signature = Signature::parse_standard_slice(&signature_a);
     });
 }
 
@@ -34,7 +34,7 @@ fn bench_signature_serialize(b: &mut Bencher) {
     assert!(signature_arr.len() == 64);
     let mut signature_a = [0u8; 64];
     signature_a.copy_from_slice(&signature_arr[0..64]);
-    let signature = Signature::parse(&signature_a);
+    let signature = Signature::parse_standard_slice(&signature_a).expect("parsed signature");
 
     b.iter(|| {
         let _serialized = signature.serialize();

--- a/core/src/ecmult.rs
+++ b/core/src/ecmult.rs
@@ -5,7 +5,9 @@ use crate::{
 };
 use alloc::{
     alloc::{alloc, Layout},
+    boxed::Box,
     vec,
+    vec::Vec,
 };
 use subtle::Choice;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
     unreachable_code,
     unused_parens
 )]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 pub use libsecp256k1_core::*;
 


### PR DESCRIPTION
Overview:
- Add no_std tag when std feature is disabled.
- Fixed errors from `cargo b --no-default-features`. 
- Fixed bench errors 

Closes #71 