### PR TITLE
Add Conversion from Affine to PublicKey

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     InvalidMessage,
     InvalidInputLength,
     TweakOutOfRange,
+    InvalidAffine
 }
 
 #[cfg(feature = "std")]
@@ -22,6 +23,7 @@ impl core::fmt::Display for Error {
             Error::InvalidMessage => write!(f, "Invalid message"),
             Error::InvalidInputLength => write!(f, "Invalid input length"),
             Error::TweakOutOfRange => write!(f, "Tweak out of range"),
+            Error::InvalidAffine => write!(f, "Invalid Affine"),
         }
     }
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -7,7 +7,7 @@ pub enum Error {
     InvalidMessage,
     InvalidInputLength,
     TweakOutOfRange,
-    InvalidAffine
+    InvalidAffine,
 }
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ impl TryFrom<Affine> for PublicKey {
     type Error = Error;
 
     fn try_from(value: Affine) -> Result<Self, Self::Error> {
-        if value.is_infinity() | !value.is_valid_var() {
+        if value.is_infinity() || !value.is_valid_var() {
             Err(Error::InvalidAffine)
         } else {
             Ok(PublicKey(value))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,12 @@ impl Into<Affine> for PublicKey {
     }
 }
 
+impl From<Affine> for PublicKey {
+    fn from(affine: Affine) -> Self {
+        PublicKey(affine)
+    }
+}
+
 #[cfg(feature = "std")]
 impl Serialize for PublicKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,14 @@
 //! Ethereum-alike cryptocurrencies.
 
 #![deny(
-unused_import_braces,
-unused_imports,
-unused_comparisons,
-unused_must_use,
-unused_variables,
-non_shorthand_field_patterns,
-unreachable_code,
-unused_parens
+    unused_import_braces,
+    unused_imports,
+    unused_comparisons,
+    unused_must_use,
+    unused_variables,
+    non_shorthand_field_patterns,
+    unreachable_code,
+    unused_parens
 )]
 
 pub use libsecp256k1_core::*;
@@ -76,10 +76,11 @@ pub struct Message(pub Scalar);
 pub struct SharedSecret<D: Digest>(GenericArray<u8, D::OutputSize>);
 
 impl<D> Copy for SharedSecret<D>
-    where
-        D: Copy + Digest,
-        GenericArray<u8, D::OutputSize>: Copy,
-{}
+where
+    D: Copy + Digest,
+    GenericArray<u8, D::OutputSize>: Copy,
+{
+}
 
 /// Format for public key parsing.
 pub enum PublicKeyFormat {
@@ -322,8 +323,8 @@ impl TryFrom<Affine> for PublicKey {
 #[cfg(feature = "std")]
 impl Serialize for PublicKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         if serializer.is_human_readable() {
             serializer.serialize_str(&base64::encode(&self.serialize()[..]))
@@ -346,8 +347,8 @@ impl<'de> de::Visitor<'de> for PublicKeyVisitor {
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-        where
-            E: de::Error,
+    where
+        E: de::Error,
     {
         let value: &[u8] = &base64::decode(value).unwrap();
         let key_format = match value.len() {
@@ -364,8 +365,8 @@ impl<'de> de::Visitor<'de> for PublicKeyVisitor {
 #[cfg(feature = "std")]
 impl<'de> Deserialize<'de> for PublicKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: de::Deserializer<'de>,
+    where
+        D: de::Deserializer<'de>,
     {
         if deserializer.is_human_readable() {
             deserializer.deserialize_str(PublicKeyVisitor)
@@ -800,9 +801,9 @@ pub fn sign_with_context(
     }
 
     #[allow(unused_assignments)]
-        {
-            nonce = Scalar::default();
-        }
+    {
+        nonce = Scalar::default();
+    }
     let (sigr, sigs, recid) = result;
 
     (Signature { r: sigr, s: sigs }, RecoveryId(recid))
@@ -831,7 +832,7 @@ mod tests {
             SecretKey::parse(&hex!(
                 "1536f1d756d1abf83aaf173bc5ee3fc487c93010f18624d80bd6d4038fadd59e"
             ))
-                .unwrap()
+            .unwrap()
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,14 @@
 //! Ethereum-alike cryptocurrencies.
 
 #![deny(
-    unused_import_braces,
-    unused_imports,
-    unused_comparisons,
-    unused_must_use,
-    unused_variables,
-    non_shorthand_field_patterns,
-    unreachable_code,
-    unused_parens
+unused_import_braces,
+unused_imports,
+unused_comparisons,
+unused_must_use,
+unused_variables,
+non_shorthand_field_patterns,
+unreachable_code,
+unused_parens
 )]
 
 pub use libsecp256k1_core::*;
@@ -51,31 +51,35 @@ pub static ECMULT_GEN_CONTEXT: ECMultGenContext =
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Public key on a secp256k1 curve.
 pub struct PublicKey(Affine);
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Secret key (256-bit) on a secp256k1 curve.
 pub struct SecretKey(Scalar);
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// An ECDSA signature.
 pub struct Signature {
     pub r: Scalar,
     pub s: Scalar,
 }
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Tag used for public key recovery from signatures.
 pub struct RecoveryId(u8);
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Hashed message input to an ECDSA signature.
 pub struct Message(pub Scalar);
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 /// Shared secret using ECDH.
 pub struct SharedSecret<D: Digest>(GenericArray<u8, D::OutputSize>);
 
 impl<D> Copy for SharedSecret<D>
-where
-    D: Copy + Digest,
-    GenericArray<u8, D::OutputSize>: Copy,
-{
-}
+    where
+        D: Copy + Digest,
+        GenericArray<u8, D::OutputSize>: Copy,
+{}
 
 /// Format for public key parsing.
 pub enum PublicKeyFormat {
@@ -303,17 +307,23 @@ impl Into<Affine> for PublicKey {
     }
 }
 
-impl From<Affine> for PublicKey {
-    fn from(affine: Affine) -> Self {
-        PublicKey(affine)
+impl TryFrom<Affine> for PublicKey {
+    type Error = Error;
+
+    fn try_from(value: Affine) -> Result<Self, Self::Error> {
+        if value.is_infinity() | !value.is_valid_var() {
+            Err(Error::InvalidAffine)
+        } else {
+            Ok(PublicKey(value))
+        }
     }
 }
 
 #[cfg(feature = "std")]
 impl Serialize for PublicKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+        where
+            S: Serializer,
     {
         if serializer.is_human_readable() {
             serializer.serialize_str(&base64::encode(&self.serialize()[..]))
@@ -336,8 +346,8 @@ impl<'de> de::Visitor<'de> for PublicKeyVisitor {
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
+        where
+            E: de::Error,
     {
         let value: &[u8] = &base64::decode(value).unwrap();
         let key_format = match value.len() {
@@ -354,8 +364,8 @@ impl<'de> de::Visitor<'de> for PublicKeyVisitor {
 #[cfg(feature = "std")]
 impl<'de> Deserialize<'de> for PublicKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
+        where
+            D: de::Deserializer<'de>,
     {
         if deserializer.is_human_readable() {
             deserializer.deserialize_str(PublicKeyVisitor)
@@ -790,9 +800,9 @@ pub fn sign_with_context(
     }
 
     #[allow(unused_assignments)]
-    {
-        nonce = Scalar::default();
-    }
+        {
+            nonce = Scalar::default();
+        }
     let (sigr, sigs, recid) = result;
 
     (Signature { r: sigr, s: sigs }, RecoveryId(recid))
@@ -821,7 +831,7 @@ mod tests {
             SecretKey::parse(&hex!(
                 "1536f1d756d1abf83aaf173bc5ee3fc487c93010f18624d80bd6d4038fadd59e"
             ))
-            .unwrap()
+                .unwrap()
         )
     }
 }


### PR DESCRIPTION
PR adds core::convert From trait for PublicKey to convert an Affine to PublicKey 