### PR TITLE
CI optimizations

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,11 +13,11 @@ jobs:
         uses:          styfle/cancel-workflow-action@0.9.1
 
       - name:          Checkout sources
-        uses:          actions/checkout@v1
+        uses:          actions/checkout@v2.3.4
         with:
           fetch-depth: 50
 
       - name:          Run cargo audit
-        uses:          actions-rs/audit-check@v1
+        uses:          actions-rs/audit-check@v1.2.0
         with:
           token:       ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,11 +8,16 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v1
+
+      - name:          Cancel Previous Runs
+        uses:          styfle/cancel-workflow-action@0.9.1
+
+      - name:          Checkout sources
+        uses:          actions/checkout@v1
         with:
           fetch-depth: 50
-      - name: Run cargo audit
-        uses: actions-rs/audit-check@v1
+
+      - name:          Run cargo audit
+        uses:          actions-rs/audit-check@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token:       ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -18,19 +18,19 @@ jobs:
       RUST_BACKTRACE:  full
     steps:
       - name:          Checkout sources & submodules
-        uses:          actions/checkout@master
+        uses:          actions/checkout@v1
         with:
           fetch-depth: 5
           submodules:  recursive
       - name:          Install toolchain
-        uses:          actions-rs/toolchain@master
+        uses:          actions-rs/toolchain@v1
         with:
           profile:     minimal
           toolchain:   stable
           components:  clippy, rustfmt
           override:    true
       - name:          Checking style
-        uses:          actions-rs/cargo@master
+        uses:          actions-rs/cargo@v1
         with:
           command:     fmt
           toolchain:   stable

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -17,11 +17,15 @@ jobs:
     env:
       RUST_BACKTRACE:  full
     steps:
+      - name:          Cancel Previous Runs
+        uses:          styfle/cancel-workflow-action@0.9.1
+
       - name:          Checkout sources & submodules
         uses:          actions/checkout@v1
         with:
           fetch-depth: 5
           submodules:  recursive
+
       - name:          Install toolchain
         uses:          actions-rs/toolchain@v1
         with:
@@ -29,6 +33,7 @@ jobs:
           toolchain:   stable
           components:  clippy, rustfmt
           override:    true
+
       - name:          Checking style
         uses:          actions-rs/cargo@v1
         with:

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -21,13 +21,13 @@ jobs:
         uses:          styfle/cancel-workflow-action@0.9.1
 
       - name:          Checkout sources & submodules
-        uses:          actions/checkout@v1
+        uses:          actions/checkout@v2.3.4
         with:
           fetch-depth: 5
           submodules:  recursive
 
       - name:          Install toolchain
-        uses:          actions-rs/toolchain@v1
+        uses:          actions-rs/toolchain@v1.0.6
         with:
           profile:     minimal
           toolchain:   stable
@@ -35,7 +35,7 @@ jobs:
           override:    true
 
       - name:          Checking style
-        uses:          actions-rs/cargo@v1
+        uses:          actions-rs/cargo@v1.0.1
         with:
           command:     fmt
           toolchain:   stable

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,11 +17,15 @@ jobs:
     env:
       RUST_BACKTRACE:  full
     steps:
+      - name:          Cancel Previous Runs
+        uses:          styfle/cancel-workflow-action@0.9.1
+
       - name:          Checkout sources & submodules
         uses:          actions/checkout@v1
         with:
           fetch-depth: 5
           submodules:  recursive
+
       - name:          Install toolchain
         uses:          actions-rs/toolchain@v1
         with:
@@ -29,12 +33,14 @@ jobs:
           toolchain:   stable
           components:  clippy, rustfmt
           override:    true
+
       - name:          Checking clippy
         uses:          actions-rs/cargo@v1
         with:
           command:     clippy
           toolchain:   stable
           args:        --all
+
       - name:          Checking clippy
         uses:          actions-rs/cargo@v1
         with:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -18,25 +18,25 @@ jobs:
       RUST_BACKTRACE:  full
     steps:
       - name:          Checkout sources & submodules
-        uses:          actions/checkout@master
+        uses:          actions/checkout@v1
         with:
           fetch-depth: 5
           submodules:  recursive
       - name:          Install toolchain
-        uses:          actions-rs/toolchain@master
+        uses:          actions-rs/toolchain@v1
         with:
           profile:     minimal
           toolchain:   stable
           components:  clippy, rustfmt
           override:    true
       - name:          Checking clippy
-        uses:          actions-rs/cargo@master
+        uses:          actions-rs/cargo@v1
         with:
           command:     clippy
           toolchain:   stable
           args:        --all
       - name:          Checking clippy
-        uses:          actions-rs/cargo@master
+        uses:          actions-rs/cargo@v1
         with:
           command:     clippy
           toolchain:   stable

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -21,13 +21,13 @@ jobs:
         uses:          styfle/cancel-workflow-action@0.9.1
 
       - name:          Checkout sources & submodules
-        uses:          actions/checkout@v1
+        uses:          actions/checkout@v2.3.4
         with:
           fetch-depth: 5
           submodules:  recursive
 
       - name:          Install toolchain
-        uses:          actions-rs/toolchain@v1
+        uses:          actions-rs/toolchain@v1.0.6
         with:
           profile:     minimal
           toolchain:   stable
@@ -35,14 +35,14 @@ jobs:
           override:    true
 
       - name:          Checking clippy
-        uses:          actions-rs/cargo@v1
+        uses:          actions-rs/cargo@v1.0.1
         with:
           command:     clippy
           toolchain:   stable
           args:        --all
 
       - name:          Checking clippy
-        uses:          actions-rs/cargo@v1
+        uses:          actions-rs/cargo@v1.0.1
         with:
           command:     clippy
           toolchain:   stable

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "daily"
+    rebase-strategy: disabled
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "daily"
+    rebase-strategy: disabled
+    open-pull-requests-limit: 2

--- a/.github/workflows/rust-windows.yml
+++ b/.github/workflows/rust-windows.yml
@@ -1,0 +1,316 @@
+# almost a copy of .github/workflows/rust.yml made in https://github.com/paritytech/libsecp256k1/pull/84
+# windows causes some troubles with sudo sccache and
+# caching within GHA https://github.com/Swatinem/rust-cache/issues/31
+name:                  Check, Test and Build on Windows
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - stable
+    tags:
+      - v*
+    paths-ignore:
+      - 'README.md'
+
+jobs:
+  check:
+    name:              Check
+    strategy:
+      matrix:
+        platform:
+          - windows-latest
+        toolchain:
+          - stable
+          - nightly
+        compiler:
+          - clang
+          - gcc
+    runs-on:           ${{ matrix.platform }}
+    env:
+      RUST_BACKTRACE:  full
+    steps:
+
+      - name:          Cancel Previous Runs
+        uses:          styfle/cancel-workflow-action@0.9.1
+
+      - name:          Install sudo for windows #https://github.com/actions/virtual-environments/issues/572
+        if: matrix.platform == 'windows-latest'
+        run: choco install sudo
+
+      - name:          Install LLVM for Windows
+        if:            matrix.platform == 'windows-latest'  && matrix.compiler == 'clang'
+        run:           |
+          choco install llvm
+          echo "CC=clang-cl.exe --enable-64-bit" >> "$GITHUB_ENV"
+          echo "CXX=clang-cl.exe --enable-64-bit" >> "$GITHUB_ENV"
+          refreshenv
+
+      - name:          Checkout sources & submodules
+        uses:          actions/checkout@v2.3.4
+        with:
+          fetch-depth: 5
+          submodules:  recursive
+
+      - name:          Install toolchain
+        id:            toolchain
+        uses:          actions-rs/toolchain@v1.0.6
+        with:
+          profile:     minimal
+          toolchain:   ${{ matrix.toolchain }}
+          components:  clippy, rustfmt
+          override:    true
+
+      - name:          Set cache_hash ENV and prepare cache dir
+        run:           |
+          echo "cache_hash=${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ matrix.compiler }}-${{ hashFiles('**/Cargo.toml') }}" >> "$GITHUB_ENV"
+          mkdir -p $HOME/sccache
+          sudo chmod -R a+w $HOME/.cargo
+        shell:         bash
+
+      - name:          Cache cargo registry
+        uses:          actions/cache@v2.1.6
+        with:
+          path:        $HOME/.cargo/registry
+          key:         cargo-registry-${{ env['cache_hash'] }}
+
+      - name:          Cache cargo index
+        uses:          actions/cache@v2.1.6
+        with:
+          path:        $HOME/.cargo/git
+          key:         cargo-git-${{ env['cache_hash'] }}
+
+      - name:          Cache cargo build
+        uses:          actions/cache@v2.1.6
+        with:
+          path:        target
+          key:         cargo-target-${{ env['cache_hash'] }}
+
+      - name:          Checking ${{ matrix.platform }}-${{ matrix.toolchain }}
+        uses:          actions-rs/cargo@v1.0.1
+        with:
+          command:     check
+          toolchain:   ${{ matrix.toolchain }}
+          args:        --all  --verbose
+
+  test:
+    name:              Test
+    needs:             [check]
+    strategy:
+      matrix:
+        platform:
+          - windows-latest
+        toolchain:
+          - stable
+          - nightly
+        compiler:
+          - clang
+          - gcc
+    runs-on:           ${{ matrix.platform }}
+    env:
+      RUST_BACKTRACE:  full
+    steps:
+
+      - name:          Cancel Previous Runs
+        uses:          styfle/cancel-workflow-action@0.9.1
+
+      - name:          Set default compiler
+        if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'
+        run: |
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
+
+      - name:          Install sudo for windows #https://github.com/actions/virtual-environments/issues/572
+        if:            matrix.platform == 'windows-latest'
+        run:           choco install sudo
+
+      - name:          Install LLVM for Windows
+        if:            matrix.platform == 'windows-latest'  && matrix.compiler == 'clang'
+        run:           |
+          choco install llvm
+          echo "CC=clang-cl.exe --enable-64-bit" >> "$GITHUB_ENV"
+          echo "CXX=clang-cl.exe --enable-64-bit" >> "$GITHUB_ENV"
+          refreshenv
+
+      - name:          Checkout sources & submodules
+        uses:          actions/checkout@v2.3.4
+        with:
+          fetch-depth: 5
+          submodules:  recursive
+
+      - name:          Install toolchain
+        id:            toolchain
+        uses:          actions-rs/toolchain@v1.0.6
+        with:
+          profile:     minimal
+          toolchain:   ${{ matrix.toolchain }}
+          components:  clippy, rustfmt
+          override:    true
+
+      - name:          Set cache_hash ENV and prepare cache dir
+        run:           |
+          echo "cache_hash=${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ matrix.compiler }}-${{ hashFiles('**/Cargo.toml') }}" >> "$GITHUB_ENV"
+          mkdir -p $HOME/sccache
+          sudo chmod -R a+w $HOME/.cargo
+        shell:         bash
+
+      - name:          Cache cargo registry
+        uses:          actions/cache@v2.1.6
+        with:
+          path:        $HOME/.cargo/registry
+          key:         cargo-registry-${{ env['cache_hash'] }}
+
+      - name:          Cache cargo index
+        uses:          actions/cache@v2.1.6
+        with:
+          path:        $HOME/.cargo/git
+          key:         cargo-git-${{ env['cache_hash'] }}
+
+      - name:          Cache cargo build
+        uses:          actions/cache@v2.1.6
+        with:
+          path:        target
+          key:         cargo-target-${{ env['cache_hash'] }}
+
+      - name:          Testing ${{ matrix.platform }}-${{ matrix.toolchain }} (debug build)
+        uses:          actions-rs/cargo@v1.0.1
+        with:
+          command:     test
+          toolchain:   ${{ matrix.toolchain }}
+          args:        --all --verbose
+
+      - name:          Testing ${{ matrix.platform }}-${{ matrix.toolchain }} (release build)
+        uses:          actions-rs/cargo@v1.0.1
+        with:
+          command:     test
+          toolchain:   ${{ matrix.toolchain }}
+          args:        --all --release --verbose
+
+  build:
+    name:              Build
+    needs:             [check,test]
+    strategy:
+      matrix:
+        platform:
+          - windows-latest
+        toolchain:
+          - stable
+          - nightly
+        compiler:
+          - clang
+          - gcc
+    runs-on:           ${{ matrix.platform }}
+    env:
+      RUST_BACKTRACE:  full
+      # NOTE:          Enables the aes-ni instructions for RustCrypto dependency.
+      # Strip binaries
+      # If you change this please remember to also update .cargo/config
+      RUSTFLAGS:       "-C target-feature=+aes,+sse2,+ssse3 -C link-arg=-s"
+    steps:
+
+      - name:          Cancel Previous Runs
+        uses:          styfle/cancel-workflow-action@0.9.1
+
+      - name:          Set default compiler
+        if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'
+        run: |
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
+
+      - name:          Install sudo for windows #https://github.com/actions/virtual-environments/issues/572
+        if: matrix.platform == 'windows-latest'
+        run: choco install sudo
+
+      - name:          Install LLVM for Windows
+        if:            matrix.platform == 'windows-latest'  && matrix.compiler == 'clang'
+        run:           |
+          choco install llvm
+          echo "CC=clang-cl.exe --enable-64-bit" >> "$GITHUB_ENV"
+          echo "CXX=clang-cl.exe --enable-64-bit" >> "$GITHUB_ENV"
+          refreshenv
+
+      - name:          Checkout sources & submodules
+        uses:          actions/checkout@v2.3.4
+        with:
+          fetch-depth: 5
+          submodules:  recursive
+
+      - name:          Install toolchain
+        id:            toolchain
+        uses:          actions-rs/toolchain@v1.0.6
+        with:
+          profile:     minimal
+          toolchain:   ${{ matrix.toolchain }}
+          components:  clippy, rustfmt
+          override:    true
+
+      - name:          Set cache_hash ENV and prepare cache dir
+        run:           |
+          echo "cache_hash=${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ matrix.compiler }}-${{ hashFiles('**/Cargo.toml') }}" >> "$GITHUB_ENV"
+          mkdir -p $HOME/sccache
+          sudo chmod -R a+w $HOME/.cargo
+        shell:         bash
+
+      - name:          Cache cargo registry
+        uses:          actions/cache@v2.1.6
+        with:
+          path:        $HOME/.cargo/registry
+          key:         cargo-registry-${{ env['cache_hash'] }}
+
+      - name:          Cache cargo index
+        uses:          actions/cache@v2.1.6
+        with:
+          path:        $HOME/.cargo/git
+          key:         cargo-git-${{ env['cache_hash'] }}
+
+      - name:          Cache cargo build
+        uses:          actions/cache@v2.1.6
+        with:
+          path:        target
+          key:         cargo-target-${{ env['cache_hash'] }}
+
+      - name:          Building ${{ matrix.platform }}-${{ matrix.toolchain }}
+        uses:          actions-rs/cargo@v1.0.1
+        with:
+          command:     build
+          toolchain:   ${{ matrix.toolchain }}
+          args:        --all --verbose --release
+
+      - name:          Building `no default` ${{ matrix.platform }}-${{ matrix.toolchain }}
+        uses:          actions-rs/cargo@v1.0.1
+        with:
+          command:     build
+          toolchain:   ${{ matrix.toolchain }}
+          args:        --verbose --no-default-features
+
+      - name:          Building `hmac` ${{ matrix.platform }}-${{ matrix.toolchain }}
+        uses:          actions-rs/cargo@v1.0.1
+        with:
+          command:     build
+          toolchain:   ${{ matrix.toolchain }}
+          args:        --verbose --no-default-features --features hmac
+
+      - name:          Building `static-context` ${{ matrix.platform }}-${{ matrix.toolchain }}
+        uses:          actions-rs/cargo@v1.0.1
+        with:
+          command:     build
+          toolchain:   ${{ matrix.toolchain }}
+          args:        --verbose --no-default-features --features static-context
+
+      - name:          Building `lazy-static-context` ${{ matrix.platform }}-${{ matrix.toolchain }}
+        uses:          actions-rs/cargo@v1.0.1
+        with:
+          command:     build
+          toolchain:   ${{ matrix.toolchain }}
+          args:        --verbose --no-default-features --features lazy-static-context
+
+      - name:          Prepare artifacts
+        run:           .github/workflows/prepare_artifacts.sh ""
+        shell:         bash
+
+      - name:          Upload artifacts
+        uses:          actions/upload-artifact@v2.2.4
+        with:
+          name:        ${{ matrix.platform }}.${{ matrix.toolchain }}.${{ matrix.compiler }}.zip
+          path:        artifacts/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
       - name:          Cancel Previous Runs
-        uses:          styfle/cancel-workflow-action@v0.9.1
+        uses:          styfle/cancel-workflow-action@0.9.1
 
       - name:          Set default compiler
         if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'
@@ -118,7 +118,7 @@ jobs:
     steps:
 
       - name:          Cancel Previous Runs
-        uses:          styfle/cancel-workflow-action@v0.9.1
+        uses:          styfle/cancel-workflow-action@0.9.1
 
       - name:          Set default compiler
         if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'
@@ -215,7 +215,7 @@ jobs:
     steps:
 
       - name:          Cancel Previous Runs
-        uses:          styfle/cancel-workflow-action@v0.9.1
+        uses:          styfle/cancel-workflow-action@0.9.1
 
       - name:          Set default compiler
         if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,25 +53,25 @@ jobs:
           refreshenv
 
       - name:          Checkout sources & submodules
-        uses:          actions/checkout@v2
+        uses:          actions/checkout@v2.3.4
         with:
           fetch-depth: 5
           submodules:  recursive
 
       - name:          Install toolchain
         id:            toolchain
-        uses:          actions-rs/toolchain@v1
+        uses:          actions-rs/toolchain@v1.0.6
         with:
           profile:     minimal
           toolchain:   ${{ matrix.toolchain }}
           components:  clippy, rustfmt
           override:    true
 
-      - uses:          Swatinem/rust-cache@v1
+      - uses:          Swatinem/rust-cache@v1.3.0
 
       - name:          Cache sccache
         if:            matrix.platform != 'windows-latest'
-        uses:          actions/cache@v2
+        uses:          actions/cache@v2.1.6
         with:
           path:        "$HOME/sccache"
           key:         sccache-${{ env['cache_hash'] }}
@@ -87,7 +87,7 @@ jobs:
 
       # here comes different part
       - name:          Checking ${{ matrix.platform }}-${{ matrix.toolchain }}
-        uses:          actions-rs/cargo@v1
+        uses:          actions-rs/cargo@v1.0.1
         with:
           command:     check
           toolchain:   ${{ matrix.toolchain }}
@@ -139,25 +139,25 @@ jobs:
           refreshenv
 
       - name:          Checkout sources & submodules
-        uses:          actions/checkout@v2
+        uses:          actions/checkout@v2.3.4
         with:
           fetch-depth: 5
           submodules:  recursive
 
       - name:          Install toolchain
         id:            toolchain
-        uses:          actions-rs/toolchain@v1
+        uses:          actions-rs/toolchain@v1.0.6
         with:
           profile:     minimal
           toolchain:   ${{ matrix.toolchain }}
           components:  clippy, rustfmt
           override:    true
 
-      - uses:          Swatinem/rust-cache@v1
+      - uses:          Swatinem/rust-cache@v1.3.0
 
       - name:          Cache sccache
         if:            matrix.platform != 'windows-latest'
-        uses:          actions/cache@v2
+        uses:          actions/cache@v2.1.6
         with:
           path:        "$HOME/sccache"
           key:         sccache-${{ env['cache_hash'] }}
@@ -173,14 +173,14 @@ jobs:
 
       # here comes different part
       - name:          Testing ${{ matrix.platform }}-${{ matrix.toolchain }} (debug build)
-        uses:          actions-rs/cargo@v1
+        uses:          actions-rs/cargo@v1.0.1
         with:
           command:     test
           toolchain:   ${{ matrix.toolchain }}
           args:        --all --verbose
 
       - name:          Testing ${{ matrix.platform }}-${{ matrix.toolchain }} (release build)
-        uses:          actions-rs/cargo@v1
+        uses:          actions-rs/cargo@v1.0.1
         with:
           command:     test
           toolchain:   ${{ matrix.toolchain }}
@@ -236,25 +236,25 @@ jobs:
           refreshenv
 
       - name:          Checkout sources & submodules
-        uses:          actions/checkout@v2
+        uses:          actions/checkout@v2.3.4
         with:
           fetch-depth: 5
           submodules:  recursive
 
       - name:          Install toolchain
         id:            toolchain
-        uses:          actions-rs/toolchain@v1
+        uses:          actions-rs/toolchain@v1.0.6
         with:
           profile:     minimal
           toolchain:   ${{ matrix.toolchain }}
           components:  clippy, rustfmt
           override:    true
 
-      - uses:          Swatinem/rust-cache@v1
+      - uses:          Swatinem/rust-cache@v1.3.0
 
       - name:          Cache sccache
         if:            matrix.platform != 'windows-latest'
-        uses:          actions/cache@v2
+        uses:          actions/cache@v2.1.6
         with:
           path:        "$HOME/sccache"
           key:         sccache-${{ env['cache_hash'] }}
@@ -270,35 +270,35 @@ jobs:
 
       # here comes different part
       - name:          Building ${{ matrix.platform }}-${{ matrix.toolchain }}
-        uses:          actions-rs/cargo@v1
+        uses:          actions-rs/cargo@v1.0.1
         with:
           command:     build
           toolchain:   ${{ matrix.toolchain }}
           args:        --all --verbose --release
 
       - name:          Building `no default` ${{ matrix.platform }}-${{ matrix.toolchain }}
-        uses:          actions-rs/cargo@v1
+        uses:          actions-rs/cargo@v1.0.1
         with:
           command:     build
           toolchain:   ${{ matrix.toolchain }}
           args:        --verbose --no-default-features
 
       - name:          Building `hmac` ${{ matrix.platform }}-${{ matrix.toolchain }}
-        uses:          actions-rs/cargo@v1
+        uses:          actions-rs/cargo@v1.0.1
         with:
           command:     build
           toolchain:   ${{ matrix.toolchain }}
           args:        --verbose --no-default-features --features hmac
 
       - name:          Building `static-context` ${{ matrix.platform }}-${{ matrix.toolchain }}
-        uses:          actions-rs/cargo@v1
+        uses:          actions-rs/cargo@v1.0.1
         with:
           command:     build
           toolchain:   ${{ matrix.toolchain }}
           args:        --verbose --no-default-features --features static-context
 
       - name:          Building `lazy-static-context` ${{ matrix.platform }}-${{ matrix.toolchain }}
-        uses:          actions-rs/cargo@v1
+        uses:          actions-rs/cargo@v1.0.1
         with:
           command:     build
           toolchain:   ${{ matrix.toolchain }}
@@ -313,7 +313,7 @@ jobs:
         shell:         bash
 
       - name:          Upload artifacts
-        uses:          actions/upload-artifact@v1
+        uses:          actions/upload-artifact@v2.2.4
         with:
           name:        ${{ matrix.platform }}.${{ matrix.toolchain }}.${{ matrix.compiler }}.zip
           path:        artifacts/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,14 +53,14 @@ jobs:
           refreshenv
 
       - name:          Checkout sources & submodules
-        uses:          actions/checkout@master
+        uses:          actions/checkout@v2
         with:
           fetch-depth: 5
           submodules:  recursive
 
       - name:          Install toolchain
         id:            toolchain
-        uses:          actions-rs/toolchain@master
+        uses:          actions-rs/toolchain@v1
         with:
           profile:     minimal
           toolchain:   ${{ matrix.toolchain }}
@@ -71,7 +71,7 @@ jobs:
 
       - name:          Cache sccache
         if:            matrix.platform != 'windows-latest'
-        uses:          actions/cache@master
+        uses:          actions/cache@v2
         with:
           path:        "$HOME/sccache"
           key:         sccache-${{ env['cache_hash'] }}
@@ -87,7 +87,7 @@ jobs:
 
       # here comes different part
       - name:          Checking ${{ matrix.platform }}-${{ matrix.toolchain }}
-        uses:          actions-rs/cargo@master
+        uses:          actions-rs/cargo@v1
         with:
           command:     check
           toolchain:   ${{ matrix.toolchain }}
@@ -139,14 +139,14 @@ jobs:
           refreshenv
 
       - name:          Checkout sources & submodules
-        uses:          actions/checkout@master
+        uses:          actions/checkout@v2
         with:
           fetch-depth: 5
           submodules:  recursive
 
       - name:          Install toolchain
         id:            toolchain
-        uses:          actions-rs/toolchain@master
+        uses:          actions-rs/toolchain@v1
         with:
           profile:     minimal
           toolchain:   ${{ matrix.toolchain }}
@@ -157,7 +157,7 @@ jobs:
 
       - name:          Cache sccache
         if:            matrix.platform != 'windows-latest'
-        uses:          actions/cache@master
+        uses:          actions/cache@v2
         with:
           path:        "$HOME/sccache"
           key:         sccache-${{ env['cache_hash'] }}
@@ -173,14 +173,14 @@ jobs:
 
       # here comes different part
       - name:          Testing ${{ matrix.platform }}-${{ matrix.toolchain }} (debug build)
-        uses:          actions-rs/cargo@master
+        uses:          actions-rs/cargo@v1
         with:
           command:     test
           toolchain:   ${{ matrix.toolchain }}
           args:        --all --verbose
 
       - name:          Testing ${{ matrix.platform }}-${{ matrix.toolchain }} (release build)
-        uses:          actions-rs/cargo@master
+        uses:          actions-rs/cargo@v1
         with:
           command:     test
           toolchain:   ${{ matrix.toolchain }}
@@ -236,14 +236,14 @@ jobs:
           refreshenv
 
       - name:          Checkout sources & submodules
-        uses:          actions/checkout@master
+        uses:          actions/checkout@v2
         with:
           fetch-depth: 5
           submodules:  recursive
 
       - name:          Install toolchain
         id:            toolchain
-        uses:          actions-rs/toolchain@master
+        uses:          actions-rs/toolchain@v1
         with:
           profile:     minimal
           toolchain:   ${{ matrix.toolchain }}
@@ -254,7 +254,7 @@ jobs:
 
       - name:          Cache sccache
         if:            matrix.platform != 'windows-latest'
-        uses:          actions/cache@master
+        uses:          actions/cache@v2
         with:
           path:        "$HOME/sccache"
           key:         sccache-${{ env['cache_hash'] }}
@@ -270,35 +270,35 @@ jobs:
 
       # here comes different part
       - name:          Building ${{ matrix.platform }}-${{ matrix.toolchain }}
-        uses:          actions-rs/cargo@master
+        uses:          actions-rs/cargo@v1
         with:
           command:     build
           toolchain:   ${{ matrix.toolchain }}
           args:        --all --verbose --release
 
       - name:          Building `no default` ${{ matrix.platform }}-${{ matrix.toolchain }}
-        uses:          actions-rs/cargo@master
+        uses:          actions-rs/cargo@v1
         with:
           command:     build
           toolchain:   ${{ matrix.toolchain }}
           args:        --verbose --no-default-features
 
       - name:          Building `hmac` ${{ matrix.platform }}-${{ matrix.toolchain }}
-        uses:          actions-rs/cargo@master
+        uses:          actions-rs/cargo@v1
         with:
           command:     build
           toolchain:   ${{ matrix.toolchain }}
           args:        --verbose --no-default-features --features hmac
 
       - name:          Building `static-context` ${{ matrix.platform }}-${{ matrix.toolchain }}
-        uses:          actions-rs/cargo@master
+        uses:          actions-rs/cargo@v1
         with:
           command:     build
           toolchain:   ${{ matrix.toolchain }}
           args:        --verbose --no-default-features --features static-context
 
       - name:          Building `lazy-static-context` ${{ matrix.platform }}-${{ matrix.toolchain }}
-        uses:          actions-rs/cargo@master
+        uses:          actions-rs/cargo@v1
         with:
           command:     build
           toolchain:   ${{ matrix.toolchain }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,6 @@ jobs:
         platform:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
         toolchain:
           - stable
           - nightly
@@ -35,22 +34,10 @@ jobs:
         uses:          styfle/cancel-workflow-action@0.9.1
 
       - name:          Set default compiler
-        if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'
+        if:            matrix.compiler == 'clang'
         run: |
           echo "CC=clang" >> "$GITHUB_ENV"
           echo "CXX=clang++" >> "$GITHUB_ENV"
-
-      - name:          Install sudo for windows #https://github.com/actions/virtual-environments/issues/572
-        if: matrix.platform == 'windows-latest'
-        run: choco install sudo
-
-      - name:          Install LLVM for Windows
-        if:            matrix.platform == 'windows-latest'  && matrix.compiler == 'clang'
-        run:           |
-          choco install llvm
-          echo "CC=clang-cl.exe --enable-64-bit" >> "$GITHUB_ENV"
-          echo "CXX=clang-cl.exe --enable-64-bit" >> "$GITHUB_ENV"
-          refreshenv
 
       - name:          Checkout sources & submodules
         uses:          actions/checkout@v2.3.4
@@ -70,19 +57,16 @@ jobs:
       - uses:          Swatinem/rust-cache@v1.3.0
 
       - name:          Cache sccache
-        if:            matrix.platform != 'windows-latest'
         uses:          actions/cache@v2.1.6
         with:
           path:        "$HOME/sccache"
           key:         sccache-${{ env['cache_hash'] }}
 
       - name:          Install & start sccache for ${{ matrix.platform }}
-        if:            matrix.platform != 'windows-latest'
         shell:         bash
         run:           .github/workflows/sccache.sh ${{ runner.os}}
 
       - name:          Sccache statistics
-        if:            matrix.platform != 'windows-latest'
         run:           sccache --show-stats
 
       # here comes different part
@@ -94,7 +78,7 @@ jobs:
           args:        --all  --verbose
 
       - name:          Stop sccache
-        if:            matrix.platform != 'windows-latest' && always()
+        if:            always()
         run:           sccache --stop-server
 
   test:
@@ -105,7 +89,6 @@ jobs:
         platform:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
         toolchain:
           - stable
           - nightly
@@ -121,22 +104,10 @@ jobs:
         uses:          styfle/cancel-workflow-action@0.9.1
 
       - name:          Set default compiler
-        if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'
+        if:            matrix.compiler == 'clang'
         run: |
           echo "CC=clang" >> "$GITHUB_ENV"
           echo "CXX=clang++" >> "$GITHUB_ENV"
-
-      - name:          Install sudo for windows #https://github.com/actions/virtual-environments/issues/572
-        if: matrix.platform == 'windows-latest'
-        run: choco install sudo
-
-      - name:          Install LLVM for Windows
-        if:            matrix.platform == 'windows-latest'  && matrix.compiler == 'clang'
-        run:           |
-          choco install llvm
-          echo "CC=clang-cl.exe --enable-64-bit" >> "$GITHUB_ENV"
-          echo "CXX=clang-cl.exe --enable-64-bit" >> "$GITHUB_ENV"
-          refreshenv
 
       - name:          Checkout sources & submodules
         uses:          actions/checkout@v2.3.4
@@ -156,19 +127,16 @@ jobs:
       - uses:          Swatinem/rust-cache@v1.3.0
 
       - name:          Cache sccache
-        if:            matrix.platform != 'windows-latest'
         uses:          actions/cache@v2.1.6
         with:
           path:        "$HOME/sccache"
           key:         sccache-${{ env['cache_hash'] }}
 
       - name:          Install & start sccache for ${{ matrix.platform }}
-        if:            matrix.platform != 'windows-latest'
         shell:         bash
         run:           .github/workflows/sccache.sh ${{ runner.os}}
 
       - name:          Sccache statistics
-        if:            matrix.platform != 'windows-latest'
         run:           sccache --show-stats
 
       # here comes different part
@@ -187,7 +155,7 @@ jobs:
           args:        --all --release --verbose
 
       - name:          Stop sccache
-        if:            matrix.platform != 'windows-latest' && always()
+        if:            always()
         run:           sccache --stop-server
 
   build:
@@ -198,7 +166,6 @@ jobs:
         platform:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
         toolchain:
           - stable
           - nightly
@@ -218,22 +185,10 @@ jobs:
         uses:          styfle/cancel-workflow-action@0.9.1
 
       - name:          Set default compiler
-        if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'
+        if:            matrix.compiler == 'clang'
         run: |
           echo "CC=clang" >> "$GITHUB_ENV"
           echo "CXX=clang++" >> "$GITHUB_ENV"
-
-      - name:          Install sudo for windows #https://github.com/actions/virtual-environments/issues/572
-        if: matrix.platform == 'windows-latest'
-        run: choco install sudo
-
-      - name:          Install LLVM for Windows
-        if:            matrix.platform == 'windows-latest'  && matrix.compiler == 'clang'
-        run:           |
-          choco install llvm
-          echo "CC=clang-cl.exe --enable-64-bit" >> "$GITHUB_ENV"
-          echo "CXX=clang-cl.exe --enable-64-bit" >> "$GITHUB_ENV"
-          refreshenv
 
       - name:          Checkout sources & submodules
         uses:          actions/checkout@v2.3.4
@@ -253,19 +208,16 @@ jobs:
       - uses:          Swatinem/rust-cache@v1.3.0
 
       - name:          Cache sccache
-        if:            matrix.platform != 'windows-latest'
         uses:          actions/cache@v2.1.6
         with:
           path:        "$HOME/sccache"
           key:         sccache-${{ env['cache_hash'] }}
 
       - name:          Install & start sccache for ${{ matrix.platform }}
-        if:            matrix.platform != 'windows-latest'
         shell:         bash
         run:           .github/workflows/sccache.sh ${{ runner.os}}
 
       - name:          Sccache statistics
-        if:            matrix.platform != 'windows-latest'
         run:           sccache --show-stats
 
       # here comes different part
@@ -305,7 +257,7 @@ jobs:
           args:        --verbose --no-default-features --features lazy-static-context
 
       - name:          Stop sccache
-        if:            matrix.platform != 'windows-latest' && always()
+        if:            always()
         run:           sccache --stop-server
 
       - name:          Prepare artifacts

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
       - name:          Cancel Previous Runs
-        uses:          styfle/cancel-workflow-action@v0.9
+        uses:          styfle/cancel-workflow-action@v0.9.1
 
       - name:          Set default compiler
         if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'
@@ -118,7 +118,7 @@ jobs:
     steps:
 
       - name:          Cancel Previous Runs
-        uses:          styfle/cancel-workflow-action@v0.9
+        uses:          styfle/cancel-workflow-action@v0.9.1
 
       - name:          Set default compiler
         if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'
@@ -215,7 +215,7 @@ jobs:
     steps:
 
       - name:          Cancel Previous Runs
-        uses:          styfle/cancel-workflow-action@v0.9
+        uses:          styfle/cancel-workflow-action@v0.9.1
 
       - name:          Set default compiler
         if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,30 +64,7 @@ jobs:
           components:  clippy, rustfmt
           override:    true
 
-      - name:          Set cache_hash ENV and prepare cache dir
-        run:           |
-          echo "cache_hash=${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ matrix.compiler }}-${{ hashFiles('**/Cargo.toml') }}" >> "$GITHUB_ENV"
-          mkdir -p $HOME/sccache
-          sudo chmod -R a+w $HOME/.cargo
-        shell:         bash
-
-      - name:          Cache cargo registry
-        uses:          actions/cache@master
-        with:
-          path:        $HOME/.cargo/registry
-          key:         cargo-registry-${{ env['cache_hash'] }}
-
-      - name:          Cache cargo index
-        uses:          actions/cache@master
-        with:
-          path:        $HOME/.cargo/git
-          key:         cargo-git-${{ env['cache_hash'] }}
-
-      - name:          Cache cargo build
-        uses:          actions/cache@master
-        with:
-          path:        target
-          key:         cargo-target-${{ env['cache_hash'] }}
+      - uses:          Swatinem/rust-cache@v1
 
       - name:          Cache sccache
         if:            matrix.platform != 'windows-latest'
@@ -170,30 +147,7 @@ jobs:
           components:  clippy, rustfmt
           override:    true
 
-      - name:          Set cache_hash ENV and prepare cache dir's #cargo dirs permission https://github.com/actions/virtual-environments/issues/572
-        run:           |
-          echo "cache_hash=${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ matrix.compiler }}-${{ hashFiles('**/Cargo.toml') }}" >> "$GITHUB_ENV"
-          mkdir -p $HOME/sccache
-          sudo chmod -R a+w $HOME/.cargo
-        shell:         bash
-
-      - name:          Cache cargo registry
-        uses:          actions/cache@master
-        with:
-          path:        $HOME/.cargo/registry
-          key:         cargo-registry-${{ env['cache_hash'] }}
-
-      - name:          Cache cargo index
-        uses:          actions/cache@master
-        with:
-          path:        $HOME/.cargo/git
-          key:         cargo-git-${{ env['cache_hash'] }}
-
-      - name:          Cache cargo build
-        uses:          actions/cache@master
-        with:
-          path:        target
-          key:         cargo-target-${{ env['cache_hash'] }}
+      - uses:          Swatinem/rust-cache@v1
 
       - name:          Cache sccache
         if:            matrix.platform != 'windows-latest'
@@ -287,30 +241,7 @@ jobs:
           components:  clippy, rustfmt
           override:    true
 
-      - name:          Set cache_hash ENV and prepare cache dir's #cargo dirs permission https://github.com/actions/virtual-environments/issues/572
-        run:           |
-          echo "cache_hash=${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ matrix.compiler }}-${{ hashFiles('**/Cargo.toml') }}" >> "$GITHUB_ENV"
-          mkdir -p $HOME/sccache
-          sudo chmod -R a+w $HOME/.cargo
-        shell:         bash
-
-      - name:          Cache cargo registry
-        uses:          actions/cache@master
-        with:
-          path:        $HOME/.cargo/registry
-          key:         cargo-registry-${{ env['cache_hash'] }}
-
-      - name:          Cache cargo index
-        uses:          actions/cache@master
-        with:
-          path:        $HOME/.cargo/git
-          key:         cargo-git-${{ env['cache_hash'] }}
-
-      - name:          Cache cargo build
-        uses:          actions/cache@master
-        with:
-          path:        target
-          key:         cargo-target-${{ env['cache_hash'] }}
+      - uses:          Swatinem/rust-cache@v1
 
       - name:          Cache sccache
         if:            matrix.platform != 'windows-latest'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
       - name:          Cancel Previous Runs
-        uses:          styfle/cancel-workflow-action@0.9
+        uses:          styfle/cancel-workflow-action@v0.9
 
       - name:          Set default compiler
         if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'
@@ -118,7 +118,7 @@ jobs:
     steps:
 
       - name:          Cancel Previous Runs
-        uses:          styfle/cancel-workflow-action@0.9
+        uses:          styfle/cancel-workflow-action@v0.9
 
       - name:          Set default compiler
         if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'
@@ -215,7 +215,7 @@ jobs:
     steps:
 
       - name:          Cancel Previous Runs
-        uses:          styfle/cancel-workflow-action@0.9
+        uses:          styfle/cancel-workflow-action@v0.9
 
       - name:          Set default compiler
         if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,9 @@ jobs:
       RUST_BACKTRACE:  full
     steps:
 
+      - name:          Cancel Previous Runs
+        uses:          styfle/cancel-workflow-action@0.9
+
       - name:          Set default compiler
         if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'
         run: |
@@ -113,6 +116,9 @@ jobs:
     env:
       RUST_BACKTRACE:  full
     steps:
+
+      - name:          Cancel Previous Runs
+        uses:          styfle/cancel-workflow-action@0.9
 
       - name:          Set default compiler
         if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'
@@ -207,6 +213,9 @@ jobs:
       # If you change this please remember to also update .cargo/config
       RUSTFLAGS:       "-C target-feature=+aes,+sse2,+ssse3 -C link-arg=-s"
     steps:
+
+      - name:          Cancel Previous Runs
+        uses:          styfle/cancel-workflow-action@0.9
 
       - name:          Set default compiler
         if:            matrix.compiler == 'clang' && matrix.platform != 'windows-latest'


### PR DESCRIPTION
- optimize caching (swatinem's action covers more rust cache)
- cancel previous CI runs on the new commits
- pin actions' versions
- add dependabot to update cargo deps and github actions versions

Also, I'd like to use simple `run:` instead of harder-readable special actions, but it's cosmetic
I'm not quite sure if `sccache` is actually helpful here, maybe it's worth a shot next time.