### PR TITLE
fix bincode deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ secp256k1-test = { package = "secp256k1", version = "0.20.3", features = ["rand-
 clear_on_drop = "0.2"
 serde_json = "1.0"
 hex-literal = "0.3.3"
+bincode = "1.3.3"
 
 [build-dependencies]
 libsecp256k1-gen-ecmult = { version = "0.3.0", path = "gen/ecmult" }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -24,3 +24,11 @@ fn test_deserialize_public_key() {
     let pkey: PublicKey = serde_json::from_str(&SERIALIZED_DEBUG_PUBLIC_KEY).unwrap();
     assert_eq!(pkey, debug_public_key());
 }
+
+#[test]
+fn test_public_key_bincode_serde() {
+    let pkey = debug_public_key();
+    let serialized_pkey: Vec<u8> = bincode::serialize(&pkey).unwrap();
+    let pkey2 = bincode::deserialize(&serialized_pkey).unwrap();
+    assert_eq!(pkey, pkey2);
+}


### PR DESCRIPTION
Currently, [the current bincode de/serialization has a bug](https://github.com/paritytech/libsecp256k1/issues/97):
* When serializing, a byte array is used from the `PublicKey::serialize` method.
* Then when deserializing, the attempt is made by default to deserialize directly into a `PublicKey` instead of calling the corresponding `PublicKey::parse_slice` function. 

Additionally, bincode serialization isn't covered in the tests.

Therefore, this PR does the following:
* Implement and use a new PublicKeyBytesVisitor for deserializing bytes to a PublicKey (Closes #97).
* Add a test to cover bincode serialization / deserialization.
* Return the base64 decoding error instead of unwrapping (Closes #105).