### PR TITLE
fix: no-std compatibility tweak (#1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ libsecp256k1-core = { version = "0.3.0", path = "core", default-features = false
 arrayref = "0.3"
 rand = { version = "0.8", default-features = false }
 digest = "0.9"
-base64 = { version = "0.13", default-features = false }
+base64 = { version = "0.13", optional = true, default-features = false }
 hmac-drbg = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 typenum = { version = "1.12", optional = true }
-serde = { version = "1.0.104", features = ["derive"], default-features = false }
+serde = { version = "1.0.104", optional = true, features = ["derive"], default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
 
 [dev-dependencies]

--- a/gen/ecmult/Cargo.toml
+++ b/gen/ecmult/Cargo.toml
@@ -9,4 +9,4 @@ repository = "https://github.com/paritytech/libsecp256k1"
 keywords = ["crypto", "ECDSA", "secp256k1", "bitcoin", "no_std"]
 
 [dependencies]
-libsecp256k1-core = { version = "0.3.0", path = "../../core" }
+libsecp256k1-core = { version = "0.3.0", path = "../../core", default-features = false }

--- a/gen/genmult/Cargo.toml
+++ b/gen/genmult/Cargo.toml
@@ -9,4 +9,4 @@ repository = "https://github.com/paritytech/libsecp256k1"
 keywords = ["crypto", "ECDSA", "secp256k1", "bitcoin", "no_std"]
 
 [dependencies]
-libsecp256k1-core = { version = "0.3.0", path = "../../core" }
+libsecp256k1-core = { version = "0.3.0", path = "../../core", default-features = false }


### PR DESCRIPTION
# Problem
Current `sp-core` crate (version `7.0.0`) with feature `full_crypto` depends on `libsecp256k1` crate with `version = "0.7", default-features = false, features = ["static-context"]`.
`full_crypto` is a feature intended for `no_std` support and `libsecp256k1` with `default-features = false` is supposed to work with `no_std`. However, `libsecp256k1` with `default-features = false` currently does not compile at least on targets `thumbv7m-none-eabi` and `thumbv7em-none-eabi` causing `sp-core` in `full_crypto` to not compile as well.

# Possible fix
`[build-dependencies]` contain `libsecp256k1-gen-ecmult` and `libsecp256k1-gen-genmult`, both depending on `libsecp256k1-core` with default features (i.e. in `std` mode).
If the `Cargo.toml` files for both `libsecp256k1-gen-ecmult` and `libsecp256k1-gen-genmult` are changed to have `libsecp256k1-core` with `default-features = false`, things keep building as before in `std` and begin to build in `no-std` as well.
Also, a few dependencies (`serde` and `base64`) get used only in `std`, but were not marked as `optional = true`, although this does not affect buildability.

We will maintain a thus fixed version of the crate for [Kampela](https://github.com/Alzymologist/Kampela) development and switch to this upstream if the issue gets resolved.