### PR TITLE
Update dependency base64 to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ libsecp256k1-core = { version = "0.3.0", path = "core", default-features = false
 arrayref = "0.3"
 rand = { version = "0.8", default-features = false }
 digest = "0.9"
-base64 = { version = "0.13", default-features = false }
+base64 = { version = "0.21", default-features = false }
 hmac-drbg = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 typenum = { version = "1.12", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ use digest::{generic_array::GenericArray, Digest};
 use rand::Rng;
 
 #[cfg(feature = "std")]
+use base64::prelude::{Engine as _, BASE64_STANDARD as BASE64};
+#[cfg(feature = "std")]
 use core::fmt;
 #[cfg(feature = "hmac")]
 use hmac_drbg::HmacDRBG;
@@ -337,7 +339,7 @@ impl Serialize for PublicKey {
         S: Serializer,
     {
         if serializer.is_human_readable() {
-            serializer.serialize_str(&base64::encode(&self.serialize()[..]))
+            serializer.serialize_str(&BASE64.encode(&self.serialize()[..]))
         } else {
             serializer.serialize_bytes(&self.serialize())
         }
@@ -360,7 +362,7 @@ impl<'de> de::Visitor<'de> for PublicKeyStrVisitor {
     where
         E: de::Error,
     {
-        let value: &[u8] = &base64::decode(value).map_err(|e| E::custom(e))?;
+        let value: &[u8] = &BASE64.decode(value).map_err(|e| E::custom(e))?;
         let key_format = match value.len() {
             33 => PublicKeyFormat::Compressed,
             64 => PublicKeyFormat::Raw,


### PR DESCRIPTION
The `base64` crate changed the api after the 0.13 releases to require more explicit choice of the encoding variant. Update so downstream users can also migrate to current releases.