### PR TITLE
Support serde w/o std and update base64 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ libsecp256k1-core = { version = "0.3.0", path = "core", default-features = false
 arrayref = "0.3"
 rand = { version = "0.8", default-features = false }
 digest = "0.9"
-base64 = { version = "0.13", default-features = false }
+base64 = { version = "0.21.2", default-features = false, optional = true }
 hmac-drbg = { version = "0.3", optional = true }
 sha2 = { version = "0.9", optional = true, default-features = false }
 typenum = { version = "1.12", optional = true }
-serde = { version = "1.0.104", features = ["derive"], default-features = false }
+serde = { version = "1.0.104", features = ["derive"], default-features = false, optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
@@ -28,14 +28,20 @@ serde_json = "1.0"
 hex = "0.4"
 hex-literal = "0.3.3"
 bincode = "1.3.3"
+serde = { version = "1.0.104", features = ["derive"], default-features = false }
 
 [build-dependencies]
 libsecp256k1-gen-ecmult = { version = "0.3.0", path = "gen/ecmult" }
 libsecp256k1-gen-genmult = { version = "0.3.0", path = "gen/genmult" }
 
 [features]
-default = ["std", "hmac", "static-context"]
-std = ["libsecp256k1-core/std", "sha2/std", "rand/std", "serde/std", "base64/std"]
+default = ["std", "serde", "hmac", "static-context"]
+# Historically, the way to get serde support for PublicKey was by
+# enabling `std` feature.  Te maintain backwards compatibility `std`
+# enables `serde` feature.  Remove `serde` from list below at least
+# once 0.8 is released.
+std = ["libsecp256k1-core/std", "sha2/std", "rand/std", "serde"]
+serde = ["dep:serde", "base64"]
 hmac = ["hmac-drbg", "sha2", "typenum"]
 static-context = []
 lazy-static-context = ["static-context", "lazy_static", "std"]

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "std")]
+#![cfg(feature = "serde")]
 
 use libsecp256k1::*;
 


### PR DESCRIPTION
By using base64’s encode_slice and decode_slice it’s possible to
implement serde serialisation without std or alloc.  Take advantage of
that and allow enabling serde support separate from std.  This is
gated by a new `serde` feature which.

To maintain backwards-compatibility make `std` feature enables `serde`
feature.  Ideally, it should be possible to enable `std` without
bringing in serde support.  We're still in 0.x releases so there’s
technically no semver issue in breaking builds, but for now it’s
probably nicer to keep `std` enabling serde support.  It probably
makes sense to remove that in 0.8.

With all that, make serde and base64 dependencies optional.
Previously, they were always included even though they were only used
if `std` feature was enabled.  Now, they are enabled only if
explicitly requested.

While at it, update base64 dependency to the newest 0.21.2 release.
