### PR TITLE
Ethereum Recovery ID range Update

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -724,7 +724,7 @@ impl RecoveryId {
 
     /// Parse recovery ID as Ethereum RPC format, starting with 27.
     pub fn parse_rpc(p: u8) -> Result<RecoveryId, Error> {
-        if p >= 27 && p < 27 + 4 {
+        if p >= 27 && p < 27 + 2 {
             RecoveryId::parse(p - 27)
         } else {
             Err(Error::InvalidRecoveryId)


### PR DESCRIPTION
The Ethereum should only accept 27/28 for signature based on the whitepaper, instead of [27,28,29,30]

reference: 
https://github.com/ethereum/yellowpaper/pull/860
https://ethereum.github.io/yellowpaper/paper.pdf
<img width="722" alt="image" src="https://github.com/user-attachments/assets/01fd6430-6637-4bf4-9dce-7e55af866c62">

