### PR TITLE
Add note that this repo is no longer maintained to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+_Please note that this repository is no longer maintained. You can use [rust-secp256k1](https://crates.io/crates/secp256k1) instead._
+
 # SECP256K1 implementation in pure Rust
 
 * [Cargo](https://crates.io/crates/libsecp256k1)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-_Please note that this repository is no longer maintained. You can use [rust-secp256k1](https://crates.io/crates/secp256k1) instead._
+_Please note that this repository is no longer maintained. You can use [k256](https://crates.io/crates/k256) instead._
 
 # SECP256K1 implementation in pure Rust
 


### PR DESCRIPTION
According to Bhargav at W3F, this repository is no longer used or maintained. I have added a note to that effect to the top of the README as well as a link to an alternative secp256k1 implementation currently being used in Polkadot.